### PR TITLE
Issue 265: Optionally support configuring a port for Webpack - without forcing a default

### DIFF
--- a/packages/liferay-npm-build-support/src/config.js
+++ b/packages/liferay-npm-build-support/src/config.js
@@ -28,7 +28,7 @@ function loadConfig() {
 	normalize(npmbuildrc, 'webpack.mainModule', 'index.js');
 	normalize(npmbuildrc, 'webpack.rules', []);
 	normalize(npmbuildrc, 'webpack.extensions', ['.js']);
-	normalize(npmbuildrc, 'webpack.port', 8080);
+	normalize(npmbuildrc, 'webpack.port', null);
 
 	normalize(npmbundlerrc, 'create-jar.output-dir', 'build');
 	normalize(

--- a/packages/liferay-npm-build-support/src/resources/start/webpack.config.js.ejs
+++ b/packages/liferay-npm-build-support/src/resources/start/webpack.config.js.ejs
@@ -11,7 +11,9 @@ module.exports = {
 	devServer: {
 		open: true,
 		openPage: '',
+	<% if (port) { %>
 		port: <%= port %>,
+	<% } %>
 		publicPath: '/o/<%= pkgName %>/',
 	},
 	plugins: [new require('copy-webpack-plugin')(['../assets'])],


### PR DESCRIPTION
This relates to my comment on https://github.com/liferay/liferay-js-toolkit/issues/265