### PR TITLE
Fixes #345 ("Custom filename for generated jar")

### DIFF
--- a/packages/liferay-npm-bundler/src/config/internal/jar.js
+++ b/packages/liferay-npm-bundler/src/config/internal/jar.js
@@ -95,6 +95,18 @@ export function getOutputDir() {
 }
 
 /**
+ * Get the output file name for JAR files. Defaults to an empty string if none is
+ * specified, requiring the caller to generate the default based upon the package 
+ * name and version specified in the package.json.
+ * @return {string}
+ */
+export function getOutputFilename() {
+	const jarConfig = getNormalizedJarConfig();
+
+	return prop.get(jarConfig, 'output-filename', '');
+}
+
+/**
  * Get normalized JAR config as an object. Note that if JAR config is false this
  * method returns an object too so it only makes sense in a context where
  * cfg.isCreateJar() has already been checked and returned true.

--- a/packages/liferay-npm-bundler/src/jar/index.js
+++ b/packages/liferay-npm-bundler/src/jar/index.js
@@ -16,7 +16,7 @@ import * as xml from './xml';
 import * as ddm from './ddm';
 
 const pkgJson = readJsonSync(path.join('.', 'package.json'));
-const jarFileName = `${pkgJson.name}-${pkgJson.version}.jar`;
+const jarFileName = (config.jar.getOutputFilename() !== '' ? config.jar.getOutputFilename() : `${pkgJson.name}-${pkgJson.version}.jar`);
 
 /**
  * Create an OSGi bundle with build's output


### PR DESCRIPTION
Maintains the existing default ('${pkgJson.name}-${pkgJson.version}.jar') jar filename, while also allowing for the optional ability to provide a static string filename within .npmbundlerrc.