### PR TITLE
React portlet update

### DIFF
--- a/packages/babel-plugin-name-amd-modules/package-lock.json
+++ b/packages/babel-plugin-name-amd-modules/package-lock.json
@@ -862,7 +862,8 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"caseless": {
 					"version": "0.12.0",
@@ -893,11 +894,13 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
@@ -1127,7 +1130,8 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"isstream": {
 					"version": "0.1.2",
@@ -1314,7 +1318,8 @@
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"punycode": {
 					"version": "1.4.1",
@@ -1347,6 +1352,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"buffer-shims": "~1.0.0",
 						"core-util-is": "~1.0.0",
@@ -1455,6 +1461,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
 					}
@@ -1529,7 +1536,8 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"uuid": {
 					"version": "3.0.1",

--- a/packages/babel-plugin-namespace-modules/package-lock.json
+++ b/packages/babel-plugin-namespace-modules/package-lock.json
@@ -862,7 +862,8 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"caseless": {
 					"version": "0.12.0",
@@ -893,11 +894,13 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
@@ -1127,7 +1130,8 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"isstream": {
 					"version": "0.1.2",
@@ -1314,7 +1318,8 @@
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"punycode": {
 					"version": "1.4.1",
@@ -1347,6 +1352,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"buffer-shims": "~1.0.0",
 						"core-util-is": "~1.0.0",
@@ -1455,6 +1461,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
 					}
@@ -1529,7 +1536,8 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"uuid": {
 					"version": "3.0.1",

--- a/packages/babel-plugin-normalize-requires/package-lock.json
+++ b/packages/babel-plugin-normalize-requires/package-lock.json
@@ -875,7 +875,8 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"combined-stream": {
 					"version": "1.0.5",
@@ -1113,6 +1114,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1261,7 +1263,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"oauth-sign": {
 					"version": "0.8.2",
@@ -1441,6 +1444,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",

--- a/packages/babel-plugin-wrap-modules-amd/package-lock.json
+++ b/packages/babel-plugin-wrap-modules-amd/package-lock.json
@@ -862,7 +862,8 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"caseless": {
 					"version": "0.12.0",
@@ -893,11 +894,13 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
@@ -1127,7 +1130,8 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"isstream": {
 					"version": "0.1.2",
@@ -1314,7 +1318,8 @@
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"punycode": {
 					"version": "1.4.1",
@@ -1347,6 +1352,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"buffer-shims": "~1.0.0",
 						"core-util-is": "~1.0.0",
@@ -1455,6 +1461,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
 					}
@@ -1529,7 +1536,8 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"uuid": {
 					"version": "3.0.1",

--- a/packages/babel-preset-liferay-standard/package-lock.json
+++ b/packages/babel-preset-liferay-standard/package-lock.json
@@ -867,7 +867,8 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"caseless": {
 					"version": "0.12.0",
@@ -898,11 +899,13 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
@@ -1132,7 +1135,8 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"isstream": {
 					"version": "0.1.2",
@@ -1319,7 +1323,8 @@
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"punycode": {
 					"version": "1.4.1",
@@ -1352,6 +1357,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"buffer-shims": "~1.0.0",
 						"core-util-is": "~1.0.0",
@@ -1460,6 +1466,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
 					}
@@ -1534,7 +1541,8 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"uuid": {
 					"version": "3.0.1",

--- a/packages/generator-liferay-js/package-lock.json
+++ b/packages/generator-liferay-js/package-lock.json
@@ -1,6 +1,8 @@
 {
-	"requires": true,
+	"name": "generator-liferay-js",
+	"version": "2.10.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
@@ -38,6 +40,7 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"micromatch": "^2.1.5",
@@ -48,6 +51,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"arr-flatten": "^1.0.1"
@@ -57,12 +61,14 @@
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
 					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true,
 					"optional": true
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"expand-range": "^1.8.1",
@@ -74,6 +80,7 @@
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-posix-bracket": "^0.1.0"
@@ -83,6 +90,7 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
@@ -91,12 +99,14 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
@@ -106,6 +116,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
@@ -115,6 +126,7 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"arr-diff": "^2.0.0",
@@ -194,6 +206,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true,
 			"optional": true
 		},
 		"atob": {
@@ -205,6 +218,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
 			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "^6.26.0",
 				"babel-polyfill": "^6.26.0",
@@ -227,6 +241,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"esutils": "^2.0.2",
@@ -236,17 +251,20 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -259,6 +277,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -266,7 +285,8 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
@@ -274,6 +294,7 @@
 			"version": "6.26.3",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-generator": "^6.26.0",
@@ -300,6 +321,7 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -310,6 +332,7 @@
 			"version": "6.26.1",
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
 			"requires": {
 				"babel-messages": "^6.23.0",
 				"babel-runtime": "^6.26.0",
@@ -325,6 +348,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
 			"requires": {
 				"babel-helper-explode-assignable-expression": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -335,6 +359,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -346,6 +371,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.26.0",
@@ -357,6 +383,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-traverse": "^6.24.1",
@@ -367,6 +394,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
 			"requires": {
 				"babel-helper-get-function-arity": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -379,6 +407,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -388,6 +417,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -397,6 +427,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -406,6 +437,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-types": "^6.26.0",
@@ -416,6 +448,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -428,6 +461,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
 			"requires": {
 				"babel-helper-optimise-call-expression": "^6.24.1",
 				"babel-messages": "^6.23.0",
@@ -441,6 +475,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-template": "^6.24.1"
@@ -450,6 +485,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -457,12 +493,14 @@
 		"babel-plugin-add-module-exports": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz",
-			"integrity": "sha1-mumh9KjcZ/DN7E9K7aHkOl/2XiU="
+			"integrity": "sha1-mumh9KjcZ/DN7E9K7aHkOl/2XiU=",
+			"dev": true
 		},
 		"babel-plugin-check-es2015-constants": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -470,22 +508,26 @@
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
 		},
 		"babel-plugin-transform-async-to-generator": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
 			"requires": {
 				"babel-helper-remap-async-to-generator": "^6.24.1",
 				"babel-plugin-syntax-async-functions": "^6.8.0",
@@ -496,6 +538,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -504,6 +547,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -512,6 +556,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-template": "^6.26.0",
@@ -524,6 +569,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
 			"requires": {
 				"babel-helper-define-map": "^6.24.1",
 				"babel-helper-function-name": "^6.24.1",
@@ -540,6 +586,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-template": "^6.24.1"
@@ -549,6 +596,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -557,6 +605,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -566,6 +615,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -574,6 +624,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
 			"requires": {
 				"babel-helper-function-name": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -584,6 +635,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -592,6 +644,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -602,6 +655,7 @@
 			"version": "6.26.2",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-strict-mode": "^6.24.1",
 				"babel-runtime": "^6.26.0",
@@ -613,6 +667,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+			"dev": true,
 			"requires": {
 				"babel-helper-hoist-variables": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -623,6 +678,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+			"dev": true,
 			"requires": {
 				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -633,6 +689,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+			"dev": true,
 			"requires": {
 				"babel-helper-replace-supers": "^6.24.1",
 				"babel-runtime": "^6.22.0"
@@ -642,6 +699,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
 			"requires": {
 				"babel-helper-call-delegate": "^6.24.1",
 				"babel-helper-get-function-arity": "^6.24.1",
@@ -655,6 +713,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -664,6 +723,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -672,6 +732,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -682,6 +743,7 @@
 			"version": "6.22.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -690,6 +752,7 @@
 			"version": "6.23.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0"
 			}
@@ -698,6 +761,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
 			"requires": {
 				"babel-helper-regex": "^6.24.1",
 				"babel-runtime": "^6.22.0",
@@ -707,12 +771,14 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				},
 				"regexpu-core": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 					"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+					"dev": true,
 					"requires": {
 						"regenerate": "^1.2.1",
 						"regjsgen": "^0.2.0",
@@ -722,12 +788,14 @@
 				"regjsgen": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-					"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+					"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+					"dev": true
 				},
 				"regjsparser": {
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+					"dev": true,
 					"requires": {
 						"jsesc": "~0.5.0"
 					}
@@ -738,6 +806,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
 			"requires": {
 				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
 				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
@@ -748,6 +817,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.10.0"
 			},
@@ -756,6 +826,7 @@
 					"version": "0.10.1",
 					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 					"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.18.0",
 						"babel-types": "^6.19.0",
@@ -768,6 +839,7 @@
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.22.0",
 				"babel-types": "^6.24.1"
@@ -777,6 +849,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"core-js": "^2.5.0",
@@ -786,7 +859,8 @@
 				"regenerator-runtime": {
 					"version": "0.10.5",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+					"dev": true
 				}
 			}
 		},
@@ -794,6 +868,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
 			"integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+			"dev": true,
 			"requires": {
 				"babel-plugin-check-es2015-constants": "^6.22.0",
 				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
@@ -831,6 +906,7 @@
 					"version": "3.2.8",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
 					"integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+					"dev": true,
 					"requires": {
 						"caniuse-lite": "^1.0.30000844",
 						"electron-to-chromium": "^1.3.47"
@@ -842,6 +918,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
 			"requires": {
 				"babel-core": "^6.26.0",
 				"babel-runtime": "^6.26.0",
@@ -856,6 +933,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
@@ -865,6 +943,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"babel-traverse": "^6.26.0",
@@ -877,6 +956,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-messages": "^6.23.0",
@@ -893,6 +973,7 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -903,6 +984,7 @@
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"esutils": "^2.0.2",
@@ -913,7 +995,8 @@
 		"babylon": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -974,6 +1057,7 @@
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
 			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"dev": true,
 			"optional": true
 		},
 		"binaryextensions": {
@@ -1065,12 +1149,14 @@
 		"camelcase": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+			"dev": true
 		},
 		"caniuse-lite": {
 			"version": "1.0.30000882",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000882.tgz",
-			"integrity": "sha512-8rH1O4z9f2RWZkVPfjgjH7o91s+1S/bnw11akv8a2WK/vby9dHwvPIOPJndB9EOLhyLY+SN78MQ1lwRcQXiveg=="
+			"integrity": "sha512-8rH1O4z9f2RWZkVPfjgjH7o91s+1S/bnw11akv8a2WK/vby9dHwvPIOPJndB9EOLhyLY+SN78MQ1lwRcQXiveg==",
+			"dev": true
 		},
 		"chalk": {
 			"version": "2.4.1",
@@ -1091,6 +1177,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"anymatch": "^1.3.0",
@@ -1108,6 +1195,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-glob": "^2.0.0"
@@ -1116,12 +1204,14 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -1174,6 +1264,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
 			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"dev": true,
 			"requires": {
 				"string-width": "^2.1.1",
 				"strip-ansi": "^4.0.0",
@@ -1208,7 +1299,8 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"collection-visit": {
 			"version": "1.0.0",
@@ -1240,7 +1332,8 @@
 		"commander": {
 			"version": "2.17.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -1260,7 +1353,8 @@
 		"convert-source-map": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
@@ -1270,7 +1364,8 @@
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -1310,7 +1405,8 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
@@ -1376,6 +1472,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
 			"requires": {
 				"repeating": "^2.0.0"
 			}
@@ -1420,17 +1517,20 @@
 		"electron-to-chromium": {
 			"version": "1.3.62",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz",
-			"integrity": "sha512-x09ndL/Gjnuk3unlAyoGyUg3wbs4w/bXurgL7wL913vXHAOWmMhrLf1VNGRaMLngmadd5Q8gsV9BFuIr6rP+Xg=="
+			"integrity": "sha512-x09ndL/Gjnuk3unlAyoGyUg3wbs4w/bXurgL7wL913vXHAOWmMhrLf1VNGRaMLngmadd5Q8gsV9BFuIr6rP+Xg==",
+			"dev": true
 		},
 		"emoji-regex": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"dev": true
 		},
 		"end-of-stream": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -1460,12 +1560,14 @@
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"execa": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
 			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "^6.0.0",
 				"get-stream": "^4.0.0",
@@ -1480,6 +1582,7 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -1530,6 +1633,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"fill-range": "^2.1.0"
@@ -1539,6 +1643,7 @@
 					"version": "2.2.4",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
 					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-number": "^2.1.0",
@@ -1552,6 +1657,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2"
@@ -1561,6 +1667,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"isarray": "1.0.0"
@@ -1570,6 +1677,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
@@ -1690,6 +1798,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true,
 			"optional": true
 		},
 		"fill-range": {
@@ -1738,6 +1847,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-in": "^1.0.1"
@@ -1754,7 +1864,8 @@
 		"fs-readdir-recursive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+			"dev": true
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -1765,6 +1876,7 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
 			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"nan": "^2.9.2",
@@ -1774,20 +1886,24 @@
 				"abbrev": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -1797,12 +1913,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"optional": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1811,31 +1927,34 @@
 				"chownr": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -1844,21 +1963,25 @@
 				"deep-extend": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -1867,11 +1990,13 @@
 				"fs.realpath": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -1887,6 +2012,7 @@
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -1900,11 +2026,13 @@
 				"has-unicode": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.21",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safer-buffer": "^2.1.0"
@@ -1913,6 +2041,7 @@
 				"ignore-walk": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -1921,6 +2050,7 @@
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -1930,17 +2060,18 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"optional": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1948,12 +2079,13 @@
 				"isarray": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"optional": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -1961,12 +2093,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
-					"optional": true,
+					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -1975,6 +2107,7 @@
 				"minizlib": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -1983,7 +2116,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"optional": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -1991,11 +2124,13 @@
 				"ms": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"debug": "^2.1.2",
@@ -2006,6 +2141,7 @@
 				"node-pre-gyp": {
 					"version": "0.10.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
@@ -2023,6 +2159,7 @@
 				"nopt": {
 					"version": "4.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"abbrev": "1",
@@ -2032,11 +2169,13 @@
 				"npm-bundled": {
 					"version": "1.0.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.1.10",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
@@ -2046,6 +2185,7 @@
 				"npmlog": {
 					"version": "4.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -2057,17 +2197,18 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"optional": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2075,16 +2216,19 @@
 				"os-homedir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -2094,16 +2238,19 @@
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.7",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"deep-extend": "^0.5.1",
@@ -2115,6 +2262,7 @@
 						"minimist": {
 							"version": "1.2.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
@@ -2122,6 +2270,7 @@
 				"readable-stream": {
 					"version": "2.3.6",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -2136,6 +2285,7 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"glob": "^7.0.5"
@@ -2143,37 +2293,43 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.5.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"optional": true,
+					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2183,6 +2339,7 @@
 				"string_decoder": {
 					"version": "1.1.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -2191,6 +2348,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2198,11 +2356,13 @@
 				"strip-json-comments": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"chownr": "^1.0.1",
@@ -2217,11 +2377,13 @@
 				"util-deprecate": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -2229,18 +2391,21 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				}
 			}
 		},
 		"get-caller-file": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.1.tgz",
-			"integrity": "sha512-SpOZHfz845AH0wJYVuZk2jWDqFmu7Xubsx+ldIpwzy5pDUpu7OJHK7QYNSA2NPlDSKQwM1GFaAkciOWjjW92Sg=="
+			"integrity": "sha512-SpOZHfz845AH0wJYVuZk2jWDqFmu7Xubsx+ldIpwzy5pDUpu7OJHK7QYNSA2NPlDSKQwM1GFaAkciOWjjW92Sg==",
+			"dev": true
 		},
 		"get-stream": {
 			"version": "3.0.0",
@@ -2286,6 +2451,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-parent": "^2.0.0",
@@ -2296,6 +2462,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-glob": "^2.0.0"
@@ -2304,12 +2471,14 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -2343,7 +2512,8 @@
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
 		},
 		"globby": {
 			"version": "8.0.1",
@@ -2397,6 +2567,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			},
@@ -2404,7 +2575,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				}
 			}
 		},
@@ -2459,6 +2631,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.1"
@@ -2525,6 +2698,7 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -2532,7 +2706,8 @@
 		"invert-kv": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+			"dev": true
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
@@ -2561,6 +2736,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"binary-extensions": "^1.0.0"
@@ -2618,12 +2794,14 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
 			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true,
 			"optional": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-primitive": "^2.0.0"
@@ -2643,6 +2821,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -2705,12 +2884,14 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
 			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true,
 			"optional": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true,
 			"optional": true
 		},
 		"is-promise": {
@@ -2791,12 +2972,14 @@
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
 		},
 		"jsesc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
@@ -2806,7 +2989,8 @@
 		"json5": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "6.0.2",
@@ -2817,6 +3001,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
 			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+			"dev": true,
 			"requires": {
 				"invert-kv": "^2.0.0"
 			}
@@ -2858,6 +3043,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -2879,6 +3065,7 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
 			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"dev": true,
 			"requires": {
 				"p-defer": "^1.0.0"
 			}
@@ -2900,12 +3087,14 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
 			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+			"dev": true,
 			"optional": true
 		},
 		"mem": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
 			"integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+			"dev": true,
 			"requires": {
 				"map-age-cleaner": "^0.1.1",
 				"mimic-fn": "^1.0.0",
@@ -3074,6 +3263,7 @@
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
 			"integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+			"dev": true,
 			"optional": true
 		},
 		"nanomatch": {
@@ -3097,7 +3287,8 @@
 		"ncp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-			"integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
+			"integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+			"dev": true
 		},
 		"nice-try": {
 			"version": "1.0.5",
@@ -3119,6 +3310,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
 			}
@@ -3127,6 +3319,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -3134,12 +3327,14 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -3181,6 +3376,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"for-own": "^0.1.4",
@@ -3214,12 +3410,14 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-locale": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
 			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+			"dev": true,
 			"requires": {
 				"execa": "^1.0.0",
 				"lcid": "^2.0.0",
@@ -3235,6 +3433,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.4",
 				"mkdirp": "^0.5.1",
@@ -3249,7 +3448,8 @@
 		"p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+			"dev": true
 		},
 		"p-finally": {
 			"version": "1.0.0",
@@ -3259,7 +3459,8 @@
 		"p-is-promise": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
+			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+			"dev": true
 		},
 		"p-limit": {
 			"version": "2.0.0",
@@ -3294,6 +3495,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"glob-base": "^0.3.0",
@@ -3305,12 +3507,14 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
@@ -3397,6 +3601,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true,
 			"optional": true
 		},
 		"pretty-bytes": {
@@ -3407,7 +3612,8 @@
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
@@ -3418,6 +3624,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -3427,6 +3634,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
 			"integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-number": "^4.0.0",
@@ -3438,6 +3646,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
 					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -3496,6 +3705,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -3515,17 +3725,20 @@
 		"regenerate": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+			"dev": true
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
 		},
 		"regex-cache": {
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"is-equal-shallow": "^0.1.3"
@@ -3559,6 +3772,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
@@ -3571,12 +3785,14 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
 		},
 		"require-main-filename": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.8.1",
@@ -3660,12 +3876,14 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
 			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+			"dev": true,
 			"optional": true
 		},
 		"set-value": {
@@ -3848,6 +4066,7 @@
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"dev": true,
 			"requires": {
 				"source-map": "^0.5.6"
 			}
@@ -3969,7 +4188,8 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -4019,7 +4239,8 @@
 		"to-fast-properties": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
 		},
 		"to-object-path": {
 			"version": "0.3.0",
@@ -4062,7 +4283,8 @@
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"tslib": {
 			"version": "1.9.3",
@@ -4168,7 +4390,8 @@
 		"user-home": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -4179,6 +4402,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+			"dev": true,
 			"requires": {
 				"user-home": "^1.1.1"
 			}
@@ -4269,12 +4493,14 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
@@ -4283,12 +4509,14 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4297,6 +4525,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4307,6 +4536,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4326,12 +4556,14 @@
 		"y18n": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"dev": true
 		},
 		"yargs": {
 			"version": "13.2.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.0.tgz",
 			"integrity": "sha512-C+2y+DJwm9JIyZqeZtBnXQWAwltzeaWWtWmLdC7mBvs46PZu8a3WOyiKfJX+pEqOfzwH7OljABNwU2XJqftk6g==",
+			"dev": true,
 			"requires": {
 				"cliui": "^4.0.0",
 				"find-up": "^3.0.0",
@@ -4349,12 +4581,14 @@
 				"ansi-regex": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
+					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+					"dev": true
 				},
 				"string-width": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
 					"integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+					"dev": true,
 					"requires": {
 						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
@@ -4365,6 +4599,7 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
 					"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.0.0"
 					}
@@ -4375,6 +4610,7 @@
 			"version": "13.0.0",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
 			"integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"

--- a/packages/generator-liferay-js/src/target-react-portlet/dependencies.json
+++ b/packages/generator-liferay-js/src/target-react-portlet/dependencies.json
@@ -15,7 +15,8 @@
 		"webpack": "4.29.6",
 		"webpack-cli": "3.3.0",
 		"webpack-dev-server": "^3.7.2",
-		"windows-build-tools": "^4.0.0"
+		"windows-build-tools": "^4.0.0",
+		"shx": "^0.3.2"
 	},
 	"dependencies": {
 		"react": "16.8.6",

--- a/packages/generator-liferay-js/src/target-react-portlet/dependencies.json
+++ b/packages/generator-liferay-js/src/target-react-portlet/dependencies.json
@@ -5,18 +5,7 @@
 		"@babel/plugin-proposal-class-properties": "^7.4.4",
 		"@babel/preset-env": "^7.4.5",
 		"@babel/preset-react": "^7.0.0",
-		"babel-loader": "^8.0.6",
-		"copy-webpack-plugin": "4.6.0",
-		"liferay-npm-build-support": "^2.10.0",
-		"liferay-npm-bundler": "^2.10.0",
-		"node-gyp": "^5.0.1",
-		"node-sass": "^4.9.4",
-		"npm-run-all": "^4.1.5",
-		"webpack": "4.29.6",
-		"webpack-cli": "3.3.0",
-		"webpack-dev-server": "^3.7.2",
-		"windows-build-tools": "^4.0.0",
-		"shx": "^0.3.2"
+		"babel-loader": "^8.0.6"
 	},
 	"dependencies": {
 		"react": "16.8.6",

--- a/packages/generator-liferay-js/src/target-react-portlet/dependencies.json
+++ b/packages/generator-liferay-js/src/target-react-portlet/dependencies.json
@@ -1,8 +1,21 @@
 {
 	"devDependencies": {
-		"babel-cli": "6.26.0",
-		"babel-preset-env": "1.7.0",
-		"babel-preset-react": "6.24.1"
+		"@babel/cli": "^7.4.4",
+		"@babel/core": "^7.4.5",
+		"@babel/plugin-proposal-class-properties": "^7.4.4",
+		"@babel/preset-env": "^7.4.5",
+		"@babel/preset-react": "^7.0.0",
+		"babel-loader": "^8.0.6",
+		"copy-webpack-plugin": "4.6.0",
+		"liferay-npm-build-support": "^2.10.0",
+		"liferay-npm-bundler": "^2.10.0",
+		"node-gyp": "^5.0.1",
+		"node-sass": "^4.9.4",
+		"npm-run-all": "^4.1.5",
+		"webpack": "4.29.6",
+		"webpack-cli": "3.3.0",
+		"webpack-dev-server": "^3.7.2",
+		"windows-build-tools": "^4.0.0"
 	},
 	"dependencies": {
 		"react": "16.8.6",

--- a/packages/generator-liferay-js/src/target-react-portlet/react-portlet.js
+++ b/packages/generator-liferay-js/src/target-react-portlet/react-portlet.js
@@ -46,23 +46,9 @@ export default class extends Generator {
 		// Configure build
 		pkgJson.mergeDependencies(dependenciesJson);
 		pkgJson.addBuildStep('babel --source-maps -d build src');
-		pkgJson.addBuildStep('npm run compile-sass');
-		pkgJson.addBuildStep('npm run clean');
-		pkgJson.addScript('start', 'npm-run-all -p watch-sass dev-server');
-		pkgJson.addScript('dev-server', 'lnbs-start');
-		pkgJson.addScript('compile-sass', 'node-sass assets/css -o assets/css');
-		pkgJson.addScript(
-			'clean',
-			'shx rm -rf build dist && shx echo cleaning complete'
-		);
-		pkgJson.addScript(
-			'watch-sass',
-			'node-sass --watch assets/css -o assets/css'
-		);
 		cp.copyFile('.babelrc');
 
 		// Configure webpack
-		//pkgJson.addDevDependency('babel-loader', '7.1.5');
 		npmbuildrc.addWebpackRule(/src\/.*\.js$/, 'babel-loader');
 
 		// Prepare text labels

--- a/packages/generator-liferay-js/src/target-react-portlet/react-portlet.js
+++ b/packages/generator-liferay-js/src/target-react-portlet/react-portlet.js
@@ -47,9 +47,14 @@ export default class extends Generator {
 		pkgJson.mergeDependencies(dependenciesJson);
 		pkgJson.addBuildStep('babel --source-maps -d build src');
 		pkgJson.addBuildStep('npm run compile-sass');
+		pkgJson.addBuildStep('npm run clean');
 		pkgJson.addScript('start', 'npm-run-all -p watch-sass dev-server');
 		pkgJson.addScript('dev-server', 'lnbs-start');
 		pkgJson.addScript('compile-sass', 'node-sass assets/css -o assets/css');
+		pkgJson.addScript(
+			'clean',
+			'shx rm -rf build dist && shx echo cleaning complete'
+		);
 		pkgJson.addScript(
 			'watch-sass',
 			'node-sass --watch assets/css -o assets/css'

--- a/packages/generator-liferay-js/src/target-react-portlet/react-portlet.js
+++ b/packages/generator-liferay-js/src/target-react-portlet/react-portlet.js
@@ -46,10 +46,18 @@ export default class extends Generator {
 		// Configure build
 		pkgJson.mergeDependencies(dependenciesJson);
 		pkgJson.addBuildStep('babel --source-maps -d build src');
+		pkgJson.addBuildStep('npm run compile-sass');
+		pkgJson.addScript('start', 'npm-run-all -p watch-sass dev-server');
+		pkgJson.addScript('dev-server', 'lnbs-start');
+		pkgJson.addScript('compile-sass', 'node-sass assets/css -o assets/css');
+		pkgJson.addScript(
+			'watch-sass',
+			'node-sass --watch assets/css -o assets/css'
+		);
 		cp.copyFile('.babelrc');
 
 		// Configure webpack
-		pkgJson.addDevDependency('babel-loader', '7.1.5');
+		//pkgJson.addDevDependency('babel-loader', '7.1.5');
 		npmbuildrc.addWebpackRule(/src\/.*\.js$/, 'babel-loader');
 
 		// Prepare text labels

--- a/packages/generator-liferay-js/src/target-react-portlet/templates/.babelrc.ejs
+++ b/packages/generator-liferay-js/src/target-react-portlet/templates/.babelrc.ejs
@@ -1,3 +1,2 @@
-{
-	"presets": ["env", "react"]
-}
+{ "presets": ["@babel/env", "@babel/react"], "plugins":
+["@babel/plugin-proposal-class-properties"] }

--- a/packages/generator-liferay-js/src/utils/modifier/npmbuildrc.js
+++ b/packages/generator-liferay-js/src/utils/modifier/npmbuildrc.js
@@ -78,11 +78,22 @@ export default class extends JsonModifier {
 			test = test.substring(1, test.length - 1);
 
 			const currentRules = prop.get(json, 'webpack.rules', []);
-
-			currentRules.push({
+			//if its babel-loader, add options for modern react
+			const rule = {
 				test,
 				use: loader,
-			});
+			};
+			if (loader === 'babel-loader') {
+				rule.use = {
+					loader: 'babel-loader',
+					options: JSON.stringify({
+						presets: ['@babel/env', '@babel/react'],
+						plugins: ['@babel/plugin-proposal-class-properties'],
+					}),
+				};
+			}
+
+			currentRules.push(rule);
 
 			prop.set(json, 'webpack.rules', currentRules);
 		});

--- a/packages/liferay-npm-build-support/package-lock.json
+++ b/packages/liferay-npm-build-support/package-lock.json
@@ -1378,7 +1378,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1743,7 +1744,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1791,6 +1793,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -1829,11 +1832,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/liferay-npm-build-support/src/scripts/start.js
+++ b/packages/liferay-npm-build-support/src/scripts/start.js
@@ -44,9 +44,19 @@ function copyWebpackResources() {
 	render('webpack.config.js', {
 		pkgName: pkgJson.name,
 		port: cfg.getWebpackPort(),
-		rules: util.inspect(
-			cfg.getWebpackRules().map(rule => {
+		rules: _util2.default.inspect(
+			cfg.getWebpackRules().map(function(rule) {
 				rule.test = new RegExp(rule.test);
+				//see if there are options for babel-loader
+				var use = rule.use;
+				if (use) {
+					var options = use.options;
+					var loader = use.loader;
+					if (options && loader === 'babel-loader') {
+						// console.log('babel-loader detected');
+						rule.use.options = JSON.stringify(options);
+					}
+				}
 				return rule;
 			})
 		),

--- a/packages/liferay-npm-build-tools-common/package-lock.json
+++ b/packages/liferay-npm-build-tools-common/package-lock.json
@@ -792,7 +792,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.1.1",
@@ -1408,7 +1409,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"semver": {
 					"version": "5.3.0",
@@ -1481,6 +1483,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}

--- a/packages/liferay-npm-bundler-plugin-inject-imports-dependencies/package-lock.json
+++ b/packages/liferay-npm-bundler-plugin-inject-imports-dependencies/package-lock.json
@@ -784,7 +784,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.1.1",
@@ -861,7 +862,8 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"caseless": {
 					"version": "0.12.0",
@@ -892,11 +894,13 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
@@ -1126,7 +1130,8 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"isstream": {
 					"version": "0.1.2",
@@ -1313,7 +1318,8 @@
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"punycode": {
 					"version": "1.4.1",
@@ -1346,6 +1352,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"buffer-shims": "~1.0.0",
 						"core-util-is": "~1.0.0",
@@ -1454,6 +1461,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
 					}
@@ -1466,6 +1474,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -1527,7 +1536,8 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"uuid": {
 					"version": "3.0.1",

--- a/packages/liferay-npm-bundler-plugin-namespace-packages/package-lock.json
+++ b/packages/liferay-npm-bundler-plugin-namespace-packages/package-lock.json
@@ -862,7 +862,8 @@
 				},
 				"buffer-shims": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"caseless": {
 					"version": "0.12.0",
@@ -893,11 +894,13 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"cryptiles": {
 					"version": "2.0.5",
@@ -1127,7 +1130,8 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"isstream": {
 					"version": "0.1.2",
@@ -1314,7 +1318,8 @@
 				},
 				"process-nextick-args": {
 					"version": "1.0.7",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"punycode": {
 					"version": "1.4.1",
@@ -1347,6 +1352,7 @@
 				"readable-stream": {
 					"version": "2.2.9",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"buffer-shims": "~1.0.0",
 						"core-util-is": "~1.0.0",
@@ -1455,6 +1461,7 @@
 				"string_decoder": {
 					"version": "1.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
 					}
@@ -1529,7 +1536,8 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"uuid": {
 					"version": "3.0.1",

--- a/packages/liferay-npm-bundler/package-lock.json
+++ b/packages/liferay-npm-bundler/package-lock.json
@@ -1687,7 +1687,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.1.1",
@@ -1752,6 +1753,7 @@
 				"boom": {
 					"version": "2.10.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"hoek": "2.x.x"
 					}
@@ -1899,6 +1901,7 @@
 				"fstream": {
 					"version": "1.0.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"inherits": "~2.0.0",
@@ -1960,7 +1963,8 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"har-schema": {
 					"version": "1.0.5",
@@ -2128,6 +2132,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2385,6 +2390,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}


### PR DESCRIPTION
I made these changes to take care of a few issues I found with the React portlet generator:

1. I think that Sass should be the default for development. I tried just using the standard sass webpack loaders for inline styles but since webpack is not used for the build process, that wasn't going to work. So I added node-sass to watch the assets folder. For node sass to work on windows, node-gyp is needed. Node-gyp needs windows-build-tools so I added that. Currently they still get installed on unix machines too and I haven't tested that. I wasn't sure of a way to check OS.

2. Class properties are currently stage 3. It's pesky writing constructors just to initialize state and binding functions. So I updated the babel presets and added the class-properties plugin for modern react features.

 I am open to discussion of optimizing the new features.