### PR TITLE
FIX #383

### DIFF
--- a/packages/liferay-npm-build-support/src/util.js
+++ b/packages/liferay-npm-build-support/src/util.js
@@ -7,7 +7,7 @@
 import child_process from 'child_process';
 import spawn from 'cross-spawn';
 import ejs from 'ejs';
-import fs from 'fs';
+import fs from 'fs-extra';
 import project from 'liferay-npm-build-tools-common/lib/project';
 import path from 'path';
 import resolveModule from 'resolve';
@@ -34,13 +34,7 @@ export class Renderer {
 
 		const outputPath = path.join(dir, name);
 
-		try {
-			fs.mkdirSync(path.dirname(outputPath), {recursive: true});
-		} catch (err) {
-			if (err.code !== 'EEXIST') {
-				throw err;
-			}
-		}
+		fs.ensureDirSync(path.dirname(outputPath));
 
 		ejs.renderFile(
 			path.join(this._templatesDir, `${template}.ejs`),

--- a/packages/liferay-npm-build-support/src/util.js
+++ b/packages/liferay-npm-build-support/src/util.js
@@ -34,7 +34,11 @@ export class Renderer {
 
 		const outputPath = path.join(dir, name);
 
-		fs.mkdirSync(path.dirname(outputPath), {recursive: true});
+		try {
+			fs.mkdirSync(path.dirname(outputPath), {recursive: true});
+		} catch (err) {
+			if (err.code !== 'EEXIST') throw err	
+		}
 
 		ejs.renderFile(
 			path.join(this._templatesDir, `${template}.ejs`),

--- a/packages/liferay-npm-build-support/src/util.js
+++ b/packages/liferay-npm-build-support/src/util.js
@@ -37,7 +37,9 @@ export class Renderer {
 		try {
 			fs.mkdirSync(path.dirname(outputPath), {recursive: true});
 		} catch (err) {
-			if (err.code !== 'EEXIST') throw err	
+			if (err.code !== 'EEXIST') {
+				throw err;
+			}
 		}
 
 		ejs.renderFile(


### PR DESCRIPTION
This change wraps the fs.mkdirSync() call in a try catch, explicitly swallowing error code EEXIST (the directory already exists, which seemed to be an issue on Windows) while bubbling up any other errors.