### PR TITLE
Fixes #384: Support npm in create-react-app integration

### DIFF
--- a/packages/generator-liferay-js/src/adapt/index.js
+++ b/packages/generator-liferay-js/src/adapt/index.js
@@ -31,8 +31,9 @@ import PkgJsonModifier from '../utils/modifier/package.json';
 import LanguagePropertiesModifier from '../utils/modifier/features/localization/Language.properties';
 
 const msg = {
-	checkForYarn: [info`
-		Checking for Yarn...
+	checkForYarn: [
+		info`
+		Checking for Yarn... 
 		`,
 	],
 	createReactAppDetected: [
@@ -69,11 +70,13 @@ const msg = {
 		supported project types and how they are detected.
 		`,
 	],
-	useNpm: [info`
+	useNpm: [
+		info`
 		NPM will be used.
 		`,
 	],
-	useYarn: [info`
+	useYarn: [
+		info`
 		Yarn will be used.
 		`,
 	],
@@ -98,7 +101,8 @@ const msg = {
 		|👋 |Welcome to Liferay JS Toolkit project adapter 
 		`,
 	],
-	yarnNotFound: [warn`
+	yarnNotFound: [
+		warn`
 		Yarn was not found on this machine. 
 		`,
 	],
@@ -114,11 +118,11 @@ export default class extends Generator {
 	constructor(args, opts) {
 		super(args, opts);
 
-	    	// This method adds support for a `--use-npm` flag (to override yarn usage where both exist)
-	    	this.option("use-npm");
+		// This method adds support for a `--use-npm` flag (to override yarn usage where both exist)
+		this.option('use-npm');
 
-	    	// Make it available to access later
-	    	this.useYarn = this.options["use-npm"] ? false : true;
+		// Make it available to access later
+		this.useYarn = this.options['use-npm'] ? false : true;
 	}
 	/**
 	 * Standard Yeoman initialization function
@@ -206,19 +210,23 @@ export default class extends Generator {
 	 */
 	install() {
 		print(msg.projectAdapted);
-		
+
 		if (this.useYarn) {
-		  	print(msg.checkForYarn);
-		  	const yarnVersionResult = this.spawnCommandSync('yarnpkg', ['--version'], {stdio: [process.stderr]});
-		
-		  	// If version check had any error, assume that we can't actually use Yarn
-		  	if (yarnVersionResult.error !== null) {
+			print(msg.checkForYarn);
+			const yarnVersionResult = this.spawnCommandSync(
+				'yarnpkg',
+				['--version'],
+				{stdio: [process.stderr]}
+			);
+
+			// If version check had any error, assume that we can't actually use Yarn
+			if (yarnVersionResult.error !== null) {
 				this.useYarn = false;
 				print(msg.yarnNotFound);
 				print(msg.useNpm);
-		  	} else {			  
+			} else {
 				print(msg.useYarn);
-		  	}
+			}
 		} else {
 			print(msg.useNpm);
 		}
@@ -226,7 +234,7 @@ export default class extends Generator {
 		this.installDependencies({
 			bower: false,
 			npm: !this.useYarn,
-		  	yarn: this.useYarn
+			yarn: this.useYarn,
 		});
 	}
 
@@ -266,7 +274,8 @@ export default class extends Generator {
 		pkgJson.addScript('build:liferay', 'lnbs-build');
 		pkgJson.addScript(
 			'deploy:liferay',
-			(this.useYarn ? 'yarn' : 'npm') + ' run build:liferay && lnbs-deploy'
+			(this.useYarn ? 'yarn' : 'npm') +
+				' run build:liferay && lnbs-deploy'
 		);
 
 		// Add portlet section

--- a/packages/liferay-npm-build-support/src/util.js
+++ b/packages/liferay-npm-build-support/src/util.js
@@ -86,7 +86,15 @@ export function runNodeModulesBin(script, args = []) {
  * @param {Array<*>} args
  */
 export function runYarnScript(script, args = []) {
-	const proc = child_process.spawnSync('yarn', ['run', script].concat(args), {
+	//check if yarn is installed
+	const checkForYarn =  child_process.spawnSync('yarnpkg', ['--version'].concat(args), {
+		shell: true,
+		stdio: 'inherit'
+	});
+
+	var packageManager = (checkForYarn.status === 0 ? 'yarn' : 'npm');
+	
+	const proc = child_process.spawnSync(packageManager, ['run', script].concat(args), {
 		shell: true,
 		stdio: 'inherit',
 	});
@@ -95,11 +103,11 @@ export function runYarnScript(script, args = []) {
 		throw proc.error;
 	} else if (proc.status != 0) {
 		throw new Error(
-			`Yarn script '${script}' finished with status ${proc.status}`
+			packageManager + ` script '${script}' finished with status ${proc.status}`
 		);
 	} else if (proc.signal) {
 		throw new Error(
-			`Yarn script '${script}' finished due to signal ${proc.signal}`
+			packageManager + ` script '${script}' finished due to signal ${proc.signal}`
 		);
 	}
 }

--- a/packages/liferay-npm-build-support/src/util.js
+++ b/packages/liferay-npm-build-support/src/util.js
@@ -87,27 +87,37 @@ export function runNodeModulesBin(script, args = []) {
  */
 export function runYarnScript(script, args = []) {
 	//check if yarn is installed
-	const checkForYarn =  child_process.spawnSync('yarnpkg', ['--version'].concat(args), {
-		shell: true,
-		stdio: 'inherit'
-	});
+	const checkForYarn = child_process.spawnSync(
+		'yarnpkg',
+		['--version'].concat(args),
+		{
+			shell: true,
+			stdio: 'inherit',
+		}
+	);
 
 	const packageManager = checkForYarn.status === 0 ? 'yarn' : 'npm';
-	
-	const proc = child_process.spawnSync(packageManager, ['run', script].concat(args), {
-		shell: true,
-		stdio: 'inherit',
-	});
+
+	const proc = child_process.spawnSync(
+		packageManager,
+		['run', script].concat(args),
+		{
+			shell: true,
+			stdio: 'inherit',
+		}
+	);
 
 	if (proc.error) {
 		throw proc.error;
 	} else if (proc.status != 0) {
 		throw new Error(
-			packageManager + ` script '${script}' finished with status ${proc.status}`
+			packageManager +
+				` script '${script}' finished with status ${proc.status}`
 		);
 	} else if (proc.signal) {
 		throw new Error(
-			packageManager + ` script '${script}' finished due to signal ${proc.signal}`
+			packageManager +
+				` script '${script}' finished due to signal ${proc.signal}`
 		);
 	}
 }

--- a/packages/liferay-npm-build-support/src/util.js
+++ b/packages/liferay-npm-build-support/src/util.js
@@ -92,7 +92,7 @@ export function runYarnScript(script, args = []) {
 		stdio: 'inherit'
 	});
 
-	var packageManager = (checkForYarn.status === 0 ? 'yarn' : 'npm');
+	const packageManager = checkForYarn.status === 0 ? 'yarn' : 'npm';
 	
 	const proc = child_process.spawnSync(packageManager, ['run', script].concat(args), {
 		shell: true,


### PR DESCRIPTION
Note: This will also have documentation impact - both to mention that NPM or Yarn are viable, and to document the availability of the --user-npm flag during the **yo liferay-js:adapt step**.