### PR TITLE
Fixes #397: Prettier scripts do not run as is on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
 	"scripts": {
 		"build": "lerna run build",
 		"ci": "npm run format:check && npm run lint && npm run test",
-		"format": "prettier --write '.*.js' 'packages/*/src/**/*.js'",
-		"format:check": "prettier --list-different '.*.js' 'packages/*/src/**/*.js'",
+		"format": "prettier --write \".*.js\" \"packages/*/src/**/*.js\"",
+		"format:check": "prettier --list-different \".*.js\" \"packages/*/src/**/*.js\"",
 		"lerna": "npm install && lerna bootstrap",
 		"lint": "eslint 'packages/*/src/*.js' 'packages/*/src/**/*.js'",
 		"lint:fix": "eslint --fix 'packages/*/src/*.js' 'packages/*/src/**/*.js'",


### PR DESCRIPTION
Updated single quotes to escaped double quotes in format, format:check script definitions. This corrects the issue for Windows, can someone else confirm that it continues to function as expected on non-Windows machines?