### PR TITLE
Fix dev server for liferay-npm-build-support

### DIFF
--- a/packages/liferay-npm-build-support/src/scripts/start.js
+++ b/packages/liferay-npm-build-support/src/scripts/start.js
@@ -81,7 +81,7 @@ function runWebpackDevServer() {
 
 	if (os.platform() === 'win32') {
 		const webpackDevServerPath = path.resolve(
-			project.dir.join('node_modules', '.bin', 'webpack-dev-server.cmd')
+			project.dir.join('node_modules', '.bin', 'webpack-dev-server.cmd')._windowsPath
 		);
 
 		proc = childProcess.spawn(webpackDevServerPath, [], {


### PR DESCRIPTION
Since version 2.13.2 webpack dev server not working:
```
internal/validators.js:125
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type object
```

This fixes this error.