### PR TITLE
chore: update for compliance with current Outbound Licensing Policy

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-GNU LESSER GENERAL PUBLIC LICENSE 
+GNU LESSER GENERAL PUBLIC LICENSE
 Version 3, 29 June 2007
 Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
 
@@ -20,24 +20,24 @@ The "Minimal Corresponding Source" for a Combined Work means the Corresponding S
 
 The "Corresponding Application Code" for a Combined Work means the object code and/or source code for the Application, including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the System Libraries of the Combined Work.
 
-1. Exception to Section 3 of the GNU GPL. 
+1. Exception to Section 3 of the GNU GPL.
 You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
 
-2. Conveying Modified Versions. 
+2. Conveying Modified Versions.
 If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may convey a copy of the modified version:
 
 a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful, or
 
 b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
 
-3. Object Code Incorporating Material from Library Header Files. 
+3. Object Code Incorporating Material from Library Header Files.
 The object code form of an Application may incorporate material from a header file that is part of the Library. You may convey such object code under terms of your choice, provided that, if the incorporated material is not limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or fewer lines in length), you do both of the following:
 
 a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its use are covered by this License.
 
 b) Accompany the object code with a copy of the GNU GPL and this license document.
 
-4. Combined Works. 
+4. Combined Works.
 You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications, if you also do each of the following:
 
 a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its use are covered by this License.
@@ -54,17 +54,17 @@ d) Do one of the following:
 
 e) Provide Installation Information, but only if you would otherwise be required to provide such information under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.)
 
-5. Combined Libraries. 
+5. Combined Libraries.
 You may place library facilities that are a work based on the Library side by side in a single library together with other library facilities that are not Applications and are not covered by this License, and convey such a combined library under terms of your choice, if you do both of the following:
 
 a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities, conveyed under the terms of this License.
 
 b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
 
-6. Revised Versions of the GNU Lesser General Public License. 
+6. Revised Versions of the GNU Lesser General Public License.
 The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
 
 Each version is given a distinguishing version number. If the Library as you received it specifies that a certain numbered version of the GNU Lesser General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that published version or of any later version published by the Free Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software Foundation.
 
-If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall 
+If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall
 apply, that proxy's public statement of acceptance of any version is permanent authorization for you to choose that version for the Library.

--- a/LICENSES/LGPL-3.0-or-later.txt
+++ b/LICENSES/LGPL-3.0-or-later.txt
@@ -1,0 +1,70 @@
+GNU LESSER GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License, supplemented by the additional permissions listed below.
+
+0. Additional Definitions.
+
+As used herein, "this License" refers to version 3 of the GNU Lesser General Public License, and the "GNU GPL" refers to version 3 of the GNU General Public License.
+
+"The Library" refers to a covered work governed by this License, other than an Application or a Combined Work as defined below.
+
+An "Application" is any work that makes use of an interface provided by the Library, but which is not otherwise based on the Library. Defining a subclass of a class defined by the Library is deemed a mode of using an interface provided by the Library.
+
+A "Combined Work" is a work produced by combining or linking an Application with the Library. The particular version of the Library with which the Combined Work was made is also called the "Linked Version".
+
+The "Minimal Corresponding Source" for a Combined Work means the Corresponding Source for the Combined Work, excluding any source code for portions of the Combined Work that, considered in isolation, are based on the Application, and not on the Linked Version.
+
+The "Corresponding Application Code" for a Combined Work means the object code and/or source code for the Application, including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the System Libraries of the Combined Work.
+
+1. Exception to Section 3 of the GNU GPL.
+You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
+
+2. Conveying Modified Versions.
+If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may convey a copy of the modified version:
+
+a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful, or
+
+b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
+
+3. Object Code Incorporating Material from Library Header Files.
+The object code form of an Application may incorporate material from a header file that is part of the Library. You may convey such object code under terms of your choice, provided that, if the incorporated material is not limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or fewer lines in length), you do both of the following:
+
+a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its use are covered by this License.
+
+b) Accompany the object code with a copy of the GNU GPL and this license document.
+
+4. Combined Works.
+You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications, if you also do each of the following:
+
+a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its use are covered by this License.
+
+b) Accompany the Combined Work with a copy of the GNU GPL and this license document.
+
+c) For a Combined Work that displays copyright notices during execution, include the copyright notice for the Library among these notices, as well as a reference directing the user to the copies of the GNU GPL and this license document.
+
+d) Do one of the following:
+
+0) Convey the Minimal Corresponding Source under the terms of this License, and the Corresponding Application Code in a form suitable for, and under terms that permit, the user to recombine or relink the Application with a modified version of the Linked Version to produce a modified Combined Work, in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.
+
+1) Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (a) uses at run time a copy of the Library already present on the user's computer system, and (b) will operate properly with a modified version of the Library that is interface-compatible with the Linked Version.
+
+e) Provide Installation Information, but only if you would otherwise be required to provide such information under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.)
+
+5. Combined Libraries.
+You may place library facilities that are a work based on the Library side by side in a single library together with other library facilities that are not Applications and are not covered by this License, and convey such a combined library under terms of your choice, if you do both of the following:
+
+a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities, conveyed under the terms of this License.
+
+b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+6. Revised Versions of the GNU Lesser General Public License.
+The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library as you received it specifies that a certain numbered version of the GNU Lesser General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that published version or of any later version published by the Free Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software Foundation.
+
+If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is permanent authorization for you to choose that version for the Library.

--- a/copyright.js
+++ b/copyright.js
@@ -1,6 +1,5 @@
 /**
- * © <%= YEAR %> Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © <%= YEAR %> Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/babel-plugin-add-module-metadata/src/__tests__/index.test.js
+++ b/packages/babel-plugin-add-module-metadata/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/babel-plugin-add-module-metadata/src/index.js
+++ b/packages/babel-plugin-add-module-metadata/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/babel-plugin-name-amd-modules/src/__tests__/index.test.js
+++ b/packages/babel-plugin-name-amd-modules/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/babel-plugin-name-amd-modules/src/index.js
+++ b/packages/babel-plugin-name-amd-modules/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/babel-plugin-namespace-amd-define/src/__tests__/index.test.js
+++ b/packages/babel-plugin-namespace-amd-define/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/babel-plugin-namespace-amd-define/src/index.js
+++ b/packages/babel-plugin-namespace-amd-define/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/babel-plugin-namespace-modules/src/__tests__/index.test.js
+++ b/packages/babel-plugin-namespace-modules/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/babel-plugin-normalize-requires/src/__tests__/index.test.js
+++ b/packages/babel-plugin-normalize-requires/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/babel-plugin-normalize-requires/src/index.js
+++ b/packages/babel-plugin-normalize-requires/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/babel-plugin-wrap-modules-amd/src/__tests__/index.test.js
+++ b/packages/babel-plugin-wrap-modules-amd/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/babel-plugin-wrap-modules-amd/src/index.js
+++ b/packages/babel-plugin-wrap-modules-amd/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/babel-preset-liferay-standard/src/index.js
+++ b/packages/babel-preset-liferay-standard/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/adapt/index.js
+++ b/packages/generator-liferay-js/src/adapt/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/config.js
+++ b/packages/generator-liferay-js/src/config.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/facet-configuration/constants.js
+++ b/packages/generator-liferay-js/src/facet-configuration/constants.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/facet-configuration/index.js
+++ b/packages/generator-liferay-js/src/facet-configuration/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/facet-configuration/sample-generator.js
+++ b/packages/generator-liferay-js/src/facet-configuration/sample-generator.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/facet-deploy/index.js
+++ b/packages/generator-liferay-js/src/facet-deploy/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/facet-localization/constants.js
+++ b/packages/generator-liferay-js/src/facet-localization/constants.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/facet-localization/index.js
+++ b/packages/generator-liferay-js/src/facet-localization/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/facet-localization/sample-generator.js
+++ b/packages/generator-liferay-js/src/facet-localization/sample-generator.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/facet-portlet/index.js
+++ b/packages/generator-liferay-js/src/facet-portlet/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/facet-project/index.js
+++ b/packages/generator-liferay-js/src/facet-project/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/facet-start/index.js
+++ b/packages/generator-liferay-js/src/facet-start/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/target-angular-portlet/angular-portlet.js
+++ b/packages/generator-liferay-js/src/target-angular-portlet/angular-portlet.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/target-angular-portlet/index.js
+++ b/packages/generator-liferay-js/src/target-angular-portlet/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/target-metaljs-portlet/index.js
+++ b/packages/generator-liferay-js/src/target-metaljs-portlet/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/target-metaljs-portlet/metaljs-portlet.js
+++ b/packages/generator-liferay-js/src/target-metaljs-portlet/metaljs-portlet.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/target-react-portlet/index.js
+++ b/packages/generator-liferay-js/src/target-react-portlet/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/target-react-portlet/react-portlet.js
+++ b/packages/generator-liferay-js/src/target-react-portlet/react-portlet.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/target-shared-bundle/index.js
+++ b/packages/generator-liferay-js/src/target-shared-bundle/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/target-shared-bundle/shared-bundle.js
+++ b/packages/generator-liferay-js/src/target-shared-bundle/shared-bundle.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/target-vanilla-portlet/index.js
+++ b/packages/generator-liferay-js/src/target-vanilla-portlet/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/target-vanilla-portlet/vanilla-portlet.js
+++ b/packages/generator-liferay-js/src/target-vanilla-portlet/vanilla-portlet.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/target-vuejs-portlet/index.js
+++ b/packages/generator-liferay-js/src/target-vuejs-portlet/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/target-vuejs-portlet/vuejs-portlet.js
+++ b/packages/generator-liferay-js/src/target-vuejs-portlet/vuejs-portlet.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/utils/JsonModifier.js
+++ b/packages/generator-liferay-js/src/utils/JsonModifier.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/utils/ProjectAnalyzer.js
+++ b/packages/generator-liferay-js/src/utils/ProjectAnalyzer.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/utils/__tests__/ProjectAnalyzer.test.js
+++ b/packages/generator-liferay-js/src/utils/__tests__/ProjectAnalyzer.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/utils/__tests__/index.test.js
+++ b/packages/generator-liferay-js/src/utils/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/utils/modifier/assets/css/styles.css.js
+++ b/packages/generator-liferay-js/src/utils/modifier/assets/css/styles.css.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/utils/modifier/features/configuration.json.js
+++ b/packages/generator-liferay-js/src/utils/modifier/features/configuration.json.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/utils/modifier/features/localization/Language.properties.js
+++ b/packages/generator-liferay-js/src/utils/modifier/features/localization/Language.properties.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/utils/modifier/gitignore.js
+++ b/packages/generator-liferay-js/src/utils/modifier/gitignore.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/utils/modifier/npmbuildrc.js
+++ b/packages/generator-liferay-js/src/utils/modifier/npmbuildrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/utils/modifier/npmbundlerrc.js
+++ b/packages/generator-liferay-js/src/utils/modifier/npmbundlerrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/generator-liferay-js/src/utils/modifier/package.json.js
+++ b/packages/generator-liferay-js/src/utils/modifier/package.json.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bridge-generator/src/liferay-npm-bridge-generator.js
+++ b/packages/liferay-npm-bridge-generator/src/liferay-npm-bridge-generator.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-support/src/config.js
+++ b/packages/liferay-npm-build-support/src/config.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-support/src/portal/portal-shell.js
+++ b/packages/liferay-npm-build-support/src/portal/portal-shell.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-support/src/scripts/__tests__/translate.test.js
+++ b/packages/liferay-npm-build-support/src/scripts/__tests__/translate.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-support/src/scripts/build/index.js
+++ b/packages/liferay-npm-build-support/src/scripts/build/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-support/src/scripts/copy-assets.js
+++ b/packages/liferay-npm-build-support/src/scripts/copy-assets.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-support/src/scripts/copy-sources.js
+++ b/packages/liferay-npm-build-support/src/scripts/copy-sources.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-support/src/scripts/deploy.js
+++ b/packages/liferay-npm-build-support/src/scripts/deploy.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-support/src/scripts/start.js
+++ b/packages/liferay-npm-build-support/src/scripts/start.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-support/src/util.js
+++ b/packages/liferay-npm-build-support/src/util.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-tools-common/src/__tests__/babel-ipc.test.js
+++ b/packages/liferay-npm-build-tools-common/src/__tests__/babel-ipc.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-tools-common/src/__tests__/file-path.test.js
+++ b/packages/liferay-npm-build-tools-common/src/__tests__/file-path.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-tools-common/src/__tests__/globs.test.js
+++ b/packages/liferay-npm-build-tools-common/src/__tests__/globs.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-tools-common/src/__tests__/imports.test.js
+++ b/packages/liferay-npm-build-tools-common/src/__tests__/imports.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-tools-common/src/__tests__/manifest.test.js
+++ b/packages/liferay-npm-build-tools-common/src/__tests__/manifest.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-tools-common/src/__tests__/modules.test.js
+++ b/packages/liferay-npm-build-tools-common/src/__tests__/modules.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-tools-common/src/__tests__/namespace.test.js
+++ b/packages/liferay-npm-build-tools-common/src/__tests__/namespace.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-tools-common/src/__tests__/packages.test.js
+++ b/packages/liferay-npm-build-tools-common/src/__tests__/packages.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-tools-common/src/__tests__/pkg-desc.test.js
+++ b/packages/liferay-npm-build-tools-common/src/__tests__/pkg-desc.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-tools-common/src/__tests__/plugin-logger.test.js
+++ b/packages/liferay-npm-build-tools-common/src/__tests__/plugin-logger.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-tools-common/src/project/__tests__/index.test.js
+++ b/packages/liferay-npm-build-tools-common/src/project/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-build-tools-common/src/project/__tests__/rules.test.js
+++ b/packages/liferay-npm-build-tools-common/src/project/__tests__/rules.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-loader-babel-loader/src/__tests__/index.test.js
+++ b/packages/liferay-npm-bundler-loader-babel-loader/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-loader-copy-loader/src/index.js
+++ b/packages/liferay-npm-bundler-loader-copy-loader/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-loader-css-loader/src/__tests__/index.test.js
+++ b/packages/liferay-npm-bundler-loader-css-loader/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-loader-css-loader/src/index.js
+++ b/packages/liferay-npm-bundler-loader-css-loader/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-loader-json-loader/src/__tests__/index.test.js
+++ b/packages/liferay-npm-bundler-loader-json-loader/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-loader-json-loader/src/index.js
+++ b/packages/liferay-npm-bundler-loader-json-loader/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-loader-sass-loader/src/__tests__/index.test.js
+++ b/packages/liferay-npm-bundler-loader-sass-loader/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-loader-style-loader/src/__tests__/index.test.js
+++ b/packages/liferay-npm-bundler-loader-style-loader/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-loader-style-loader/src/index.js
+++ b/packages/liferay-npm-bundler-loader-style-loader/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-plugin-exclude-imports/src/__tests__/index.test.js
+++ b/packages/liferay-npm-bundler-plugin-exclude-imports/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-plugin-exclude-imports/src/index.js
+++ b/packages/liferay-npm-bundler-plugin-exclude-imports/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-plugin-inject-imports-dependencies/src/__tests__/index.test.js
+++ b/packages/liferay-npm-bundler-plugin-inject-imports-dependencies/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-plugin-inject-imports-dependencies/src/index.js
+++ b/packages/liferay-npm-bundler-plugin-inject-imports-dependencies/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-plugin-inject-peer-dependencies/src/__tests__/index.test.js
+++ b/packages/liferay-npm-bundler-plugin-inject-peer-dependencies/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-plugin-inject-peer-dependencies/src/index.js
+++ b/packages/liferay-npm-bundler-plugin-inject-peer-dependencies/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-plugin-namespace-packages/src/__tests__/index.test.js
+++ b/packages/liferay-npm-bundler-plugin-namespace-packages/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-plugin-namespace-packages/src/index.js
+++ b/packages/liferay-npm-bundler-plugin-namespace-packages/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler-plugin-resolve-linked-dependencies/src/index.js
+++ b/packages/liferay-npm-bundler-plugin-resolve-linked-dependencies/src/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/__tests__/dependencies.test.js
+++ b/packages/liferay-npm-bundler/src/__tests__/dependencies.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/dependencies.js
+++ b/packages/liferay-npm-bundler/src/dependencies.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/insight.js
+++ b/packages/liferay-npm-bundler/src/insight.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/jar/__tests__/ddm.test.js
+++ b/packages/liferay-npm-bundler/src/jar/__tests__/ddm.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/jar/__tests__/xml.test.js
+++ b/packages/liferay-npm-bundler/src/jar/__tests__/xml.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/jar/ddm.js
+++ b/packages/liferay-npm-bundler/src/jar/ddm.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/jar/index.js
+++ b/packages/liferay-npm-bundler/src/jar/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/jar/xml.js
+++ b/packages/liferay-npm-bundler/src/jar/xml.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/log.js
+++ b/packages/liferay-npm-bundler/src/log.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/manifest.js
+++ b/packages/liferay-npm-bundler/src/manifest.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/report/__tests__/index.test.js
+++ b/packages/liferay-npm-bundler/src/report/__tests__/index.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/report/analytics.js
+++ b/packages/liferay-npm-bundler/src/report/analytics.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/report/html.js
+++ b/packages/liferay-npm-bundler/src/report/html.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/report/index.js
+++ b/packages/liferay-npm-bundler/src/report/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/steps/__tests__/rules.test.js
+++ b/packages/liferay-npm-bundler/src/steps/__tests__/rules.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/steps/__tests__/transform.test.js
+++ b/packages/liferay-npm-bundler/src/steps/__tests__/transform.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/steps/copy.js
+++ b/packages/liferay-npm-bundler/src/steps/copy.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/steps/rules.js
+++ b/packages/liferay-npm-bundler/src/steps/rules.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-bundler/src/steps/util.js
+++ b/packages/liferay-npm-bundler/src/steps/util.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-imports-checker/src/__tests__/config.test.js
+++ b/packages/liferay-npm-imports-checker/src/__tests__/config.test.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-imports-checker/src/config.js
+++ b/packages/liferay-npm-imports-checker/src/config.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/packages/liferay-npm-imports-checker/src/liferay-npm-imports-checker.js
+++ b/packages/liferay-npm-imports-checker/src/liferay-npm-imports-checker.js
@@ -1,6 +1,5 @@
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/resources/devtools/find-generator/find-generator.js
+++ b/resources/devtools/find-generator/find-generator.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
+
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/resources/devtools/link-js-toolkit/link-js-toolkit.js
+++ b/resources/devtools/link-js-toolkit/link-js-toolkit.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
+
 /**
- * © 2017 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2017 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 


### PR DESCRIPTION
This change is analogous to the one I made in:

- https://github.com/liferay/eslint-config-liferay/pull/151
- https://github.com/liferay/liferay-npm-tools/pull/394
- https://github.com/liferay/liferay-js-themes-toolkit/pull/441
- https://github.com/liferay/clay/pull/2947
- https://github.com/liferay/alloy-editor/pull/1382
- https://github.com/liferay/liferay-amd-loader/pull/227

It updates the license header format to match the latest policy:

https://grow.liferay.com/excellence/Liferay+Outbound+Licensing+Policy

Did this by updating `copyright.js` and running `yarn lint:fix`. I used a Vim macro to strip out the original headers and preserve the original copyright dates.

Adds a copy of the license to `LICENSES/LGPL-3.0-or-later.txt` as required by the policy too.