### PR TITLE
fix: #545 Generated portlet won't display values because of wrong data type in configuration

### DIFF
--- a/packages/liferay-npm-bundler/src/jar/__tests__/__snapshots__/expected.preferences.json
+++ b/packages/liferay-npm-bundler/src/jar/__tests__/__snapshots__/expected.preferences.json
@@ -2,8 +2,8 @@
 	"availableLanguageIds": [],
 	"fields": [
 		{
-			"dataType": "number",
-			"type": "ddm-number",
+			"dataType": "integer",
+			"type": "numeric",
 			"name": "a-number",
 			"label": {
 				"": "A number"
@@ -17,7 +17,7 @@
 		},
 		{
 			"dataType": "double",
-			"type": "ddm-decimal",
+			"type": "numeric",
 			"name": "a-float",
 			"label": {
 				"": "A float"

--- a/packages/liferay-npm-bundler/src/jar/__tests__/__snapshots__/expected.preferences.l10n.json
+++ b/packages/liferay-npm-bundler/src/jar/__tests__/__snapshots__/expected.preferences.l10n.json
@@ -2,8 +2,8 @@
 	"availableLanguageIds": ["es_ES"],
 	"fields": [
 		{
-			"dataType": "number",
-			"type": "ddm-number",
+			"dataType": "integer",
+			"type": "numeric",
 			"name": "a-number",
 			"label": {
 				"": "A number",

--- a/packages/liferay-npm-bundler/src/jar/ddm.js
+++ b/packages/liferay-npm-bundler/src/jar/ddm.js
@@ -108,14 +108,14 @@ function getTypeProps(props) {
 
 		case 'number':
 			return {
-				dataType: 'number',
-				type: 'ddm-number',
+				dataType: 'integer',
+				type: 'numeric',
 			};
 
 		case 'float':
 			return {
 				dataType: 'double',
-				type: 'ddm-decimal',
+				type: 'numeric',
 			};
 
 		case 'boolean':


### PR DESCRIPTION
Simply change the literals we were writing to the JAR file because they were incorrect DDM values.