### PR TITLE
fix: #535 fail build if no exports configured

### DIFF
--- a/packages/liferay-npm-bundler/src/steps/webpack/configure.ts
+++ b/packages/liferay-npm-bundler/src/steps/webpack/configure.ts
@@ -11,6 +11,7 @@ import webpack from 'webpack';
 
 import {buildGeneratedDir, buildWebpackDir} from '../../dirs';
 import * as log from '../../log';
+import {abort} from '../util';
 
 export default function configure(): webpack.Configuration {
 	// Get user's config
@@ -42,6 +43,14 @@ export default function configure(): webpack.Configuration {
 		},
 		{}
 	);
+
+	if (Object.keys(webpackConfig.entry).length === 0) {
+		abort(
+			'Please configure at least one export in the project ' +
+				`(or add a 'main' entry to your package.json, or create an ` +
+				`'index.js' file in the project's folder)`
+		);
+	}
 
 	// Override output configuration
 	overrideWarn('output', webpackConfig.output);


### PR DESCRIPTION
It doesn't make sense to have no exports in a build because it would be unusable (as if you didn't define any entry in webpack).