### PR TITLE
fix: #553 wrap module definitions into an IIFE

### DIFF
--- a/packages/babel-plugin-wrap-modules-amd/src/index.js
+++ b/packages/babel-plugin-wrap-modules-amd/src/index.js
@@ -135,9 +135,11 @@ function applyUserDefinedTemplateIfPresent(filename, defineNode, log) {
 
 	log.info('wrap-modules-amd', 'Applied user template to wrap file');
 
-	const buildUserTemplate = template(
-		fs.readFileSync(templateFile).toString()
-	);
+	const buildUserTemplate = template(`
+		(function() {
+			${fs.readFileSync(templateFile).toString()}
+		})();
+	`);
 
 	fs.unlinkSync(templateFile);
 


### PR DESCRIPTION
See issue #553 for a full description of what happened and the commit for how it's fixed.