### PR TITLE
fix: #512 logo broken in create-react-app

### DIFF
--- a/packages/liferay-npm-bundler-preset-create-react-app/config.json
+++ b/packages/liferay-npm-bundler-preset-create-react-app/config.json
@@ -82,13 +82,7 @@
 			"test": "",
 			"include": [
 				"^build/static/css/.*\\.css$",
-				"^build/static/js/.*\\.js$",
-				"^build/static/media/.*\\.eot$",
-				"^build/static/media/.*\\.svg$",
-				"^build/static/media/.*\\.otf",
-				"^build/static/media/.*\\.ttf",
-				"^build/static/media/.*\\.woff$",
-				"^build/static/media/.*\\.woff2$"
+				"^build/static/js/.*\\.js$"
 			],
 			"use": [
 				{


### PR DESCRIPTION
This was caused by #477 where we introduced a step to remove webpack hashes from
static media files when it was not
really needed (as we don't rewrite the static media file names, just the .js
ones).

Tested manually by simply adapting a default create-react-app application.