### PR TITLE
fix: #588 enhance error detection on dynamic requires

### DIFF
--- a/packages/babel-plugin-wrap-modules-amd/src/index.js
+++ b/packages/babel-plugin-wrap-modules-amd/src/index.js
@@ -53,11 +53,19 @@ export default function({types: t}) {
 				) {
 					const argument0 = parent.arguments[0];
 
-					if (t.isLiteral(argument0)) {
-						const moduleName = argument0.value;
+					if (argument0.type !== 'StringLiteral') {
+						log.error(
+							'wrap-modules-amd',
+							'Module has a non static require, which is not ' +
+								'supported: module may fail when executed'
+						).linkToIssue(588);
 
-						dependencies[moduleName] = moduleName;
+						return;
 					}
+
+					const moduleName = argument0.value;
+
+					dependencies[moduleName] = moduleName;
 				}
 			}
 		},

--- a/packages/babel-plugin-wrap-modules-amd/src/index.js
+++ b/packages/babel-plugin-wrap-modules-amd/src/index.js
@@ -47,26 +47,39 @@ export default function({types: t}) {
 				}
 
 				if (
-					t.isCallExpression(parent) &&
-					parent.callee === node &&
-					parent.arguments.length == 1
+					!t.isCallExpression(parent) ||
+					parent.callee !== node ||
+					parent.arguments.length != 1
 				) {
-					const argument0 = parent.arguments[0];
+					return;
+				}
 
-					if (argument0.type !== 'StringLiteral') {
-						log.error(
-							'wrap-modules-amd',
-							'Module has a non static require, which is not ' +
-								'supported: module may fail when executed'
-						).linkToIssue(588);
+				const argument0 = parent.arguments[0];
 
-						return;
-					}
-
+				if (argument0.type === 'StringLiteral') {
 					const moduleName = argument0.value;
 
 					dependencies[moduleName] = moduleName;
+
+					return;
 				}
+
+				if (
+					argument0.type === 'TemplateLiteral' &&
+					argument0.quasis.length === 1
+				) {
+					const moduleName = argument0.quasis[0].value.raw;
+
+					dependencies[moduleName] = moduleName;
+
+					return;
+				}
+
+				log.error(
+					'wrap-modules-amd',
+					'Module has a non static require, which is not ' +
+						'supported: module may fail when executed'
+				).linkToIssue(588);
 			}
 		},
 	};


### PR DESCRIPTION
NOTE: THIS DOES NOT FIX #588 ENTIRELY, JUST MAKES IT A BIT LESS PROBLEMATIC

I have added code to ignore dynamic requires during build time. Now we don't
generate the undefined dependency, just skip it and let it fail during execution
of the module (note that it may even not fail if the code flow doesn't make the
dynamic require to be executed).

Also, an error is written to the report file.

This should alleviate the problem because:

1. It may make some setups work (as long as they don't execute the dynamic
   require)
2. If they execute the require, a better error will be shown in the console
3. The problem is correctly explained in the report file

I have tested the PR manually with the package involved in issue #588