### PR TITLE
fix: #589 wrap when define calls exist

### DIFF
--- a/packages/babel-plugin-namespace-amd-define/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin-namespace-amd-define/src/__tests__/__snapshots__/index.test.js.snap
@@ -39,7 +39,7 @@ var a = {
 };"
 `;
 
-exports[`logs results correctly 1`] = `
+exports[`logs warnings when more than one global define appears 1`] = `
 Array [
   Object {
     "level": "info",
@@ -53,7 +53,7 @@ Array [
     "source": "namespace-amd-define",
     "things": Array [
       "Found",
-      2,
+      1,
       "define() calls inside the module definition",
       "which have been ignored as they should never",
       "be executed during runtime",

--- a/packages/babel-plugin-namespace-amd-define/src/__tests__/index.test.js
+++ b/packages/babel-plugin-namespace-amd-define/src/__tests__/index.test.js
@@ -17,12 +17,27 @@ beforeEach(() => {
 	});
 });
 
-it('logs results correctly', () => {
+it('logs nothing when only one define appears', () => {
 	const source = `
 	define([], function(){})
 	if (typeof define === "function" && define.amd) {
 		console.log('UMD!');
 	}
+	`;
+
+	babel.transform(source, {
+		filename: __filename,
+		plugins: [plugin],
+	});
+
+	expect(logger.messages).toEqual([]);
+});
+
+it('logs warnings when more than one global define appears', () => {
+	const source = `
+	define([], function(){
+		define("something");
+	})
 	`;
 
 	babel.transform(source, {

--- a/packages/babel-plugin-namespace-amd-define/src/index.js
+++ b/packages/babel-plugin-namespace-amd-define/src/index.js
@@ -32,33 +32,21 @@ export default function() {
 					return;
 				}
 
-				let scope;
-
-				// Find if 'define' is defined in any scope
-				for (scope = path.scope; scope != null; scope = scope.parent) {
-					if (scope.bindings.define || scope.globals.define) {
-						break;
-					}
+				if (path.parent.type !== 'CallExpression') {
+					return;
 				}
 
-				if (
-					scope == null ||
-					(scope.parent == null && !scope.bindings.define)
-				) {
-					// If 'define' is not defined in any scope namespace or
-					// defined in the root scope as global...
-					if (!firstDefineNamespaced) {
-						// ...and it's its first appearance, namespace it
+				if (!firstDefineNamespaced) {
+					if (path.scope.parent === null) {
 						const namespace =
 							this.opts.namespace || 'Liferay.Loader';
 
 						path.node.name = `${namespace}.define`;
 
 						firstDefineNamespaced = true;
-					} else {
-						// ...and appeared before, record a new extra appearance
-						extraNamespaceCount++;
 					}
+				} else {
+					extraNamespaceCount++;
 				}
 			}
 		},


### PR DESCRIPTION
The code in this commit apparently goes against #68 and #74, but since #111 was
fixes, they are no longer needed as all modules think they are inside Node.js,
so there's no need to namespace anything but the first define() call.

Tested with package `string.prototype.trimright` of #589.