### PR TITLE
feat: #596 support 'global' object

### DIFF
--- a/packages/babel-plugin-wrap-modules-amd/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin-wrap-modules-amd/src/__tests__/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`correctly wraps modules 1`] = `
 "define(['module', 'exports', 'require'], function (module, exports, require) {
 	var define = undefined;
+	var global = window;
 
 	console.log('Say something');
 	if (1 == 0) {

--- a/packages/babel-plugin-wrap-modules-amd/src/index.js
+++ b/packages/babel-plugin-wrap-modules-amd/src/index.js
@@ -11,7 +11,8 @@ import PluginLogger from 'liferay-npm-build-tools-common/lib/plugin-logger';
 const buildDefine = template(`
      define(DEPS, function(module, exports, require) {
         // Make module believe it is running under Node.js
-        var define = undefined;
+		var define = undefined;
+		var global = window;
  	    SOURCE
      })
  `);


### PR DESCRIPTION
Simply define a `global` object pointing to `window` like webpack does so that
some modules work without problems.

Tested with package `string.prototype.trimright` of #589.