### PR TITLE
fix: #604 put module definition in a block scope

### DIFF
--- a/packages/babel-plugin-wrap-modules-amd/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin-wrap-modules-amd/src/__tests__/__snapshots__/index.test.js.snap
@@ -4,12 +4,13 @@ exports[`correctly wraps modules 1`] = `
 "define(['module', 'exports', 'require'], function (module, exports, require) {
 	var define = undefined;
 	var global = window;
-
-	console.log('Say something');
-	if (1 == 0) {
-		console.log('Something broke in the Matrix');
+	{
+		console.log('Say something');
+		if (1 == 0) {
+			console.log('Something broke in the Matrix');
+		}
+		module.exports = 'All OK';
 	}
-	module.exports = 'All OK';
 });"
 `;
 

--- a/packages/babel-plugin-wrap-modules-amd/src/index.js
+++ b/packages/babel-plugin-wrap-modules-amd/src/index.js
@@ -13,7 +13,9 @@ const buildDefine = template(`
         // Make module believe it is running under Node.js
 		var define = undefined;
 		var global = window;
- 	    SOURCE
+		{
+		  SOURCE
+		}
      })
  `);
 


### PR DESCRIPTION
This is to avoid the variable declarations on top of the module definition be
mixed with module's ones because of hoisting.

See the #604 issue for a more detailed explanation of this commit.