### PR TITLE
fix: #565 don't break source maps

### DIFF
--- a/packages/liferay-js-toolkit-core/src/index.ts
+++ b/packages/liferay-js-toolkit-core/src/index.ts
@@ -67,7 +67,10 @@ export type {
 export type {default as PkgJson} from './schema/PkgJson';
 
 // JavaScript AST helpers
-export {getProgramStatements as getAstProgramStatements} from './transform/js/ast';
+export {
+	getProgramStatements as getAstProgramStatements,
+	mapNodeLocation as mapAstNodeLocation,
+} from './transform/js/ast';
 export {
 	parse as parseAsAstProgram,
 	parseAsExpressionStatement as parseAsAstExpressionStatement,

--- a/packages/liferay-js-toolkit-core/src/transform/js/ast.ts
+++ b/packages/liferay-js-toolkit-core/src/transform/js/ast.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+import clone from 'clone';
+import * as estraverse from 'estraverse';
 import estree from 'estree';
 
 const STATEMENT_NODES = new Set([
@@ -28,6 +30,36 @@ const STATEMENT_NODES = new Set([
 	'WhileStatement',
 	'WithStatement',
 ]);
+
+/**
+ * Replaces source code locations of `newNode` with the ones in `originalNode`
+ * so that source maps maintain equivalence.
+ *
+ * @remarks
+ * This method does not modify the `newNode` object.
+ *
+ * @param newNode
+ * @param originalNode
+ * @return returns the modified node
+ */
+export function mapNodeLocation<T extends estree.Node>(
+	newNode: estree.Node,
+	originalNode: T
+): T {
+	const clonedNewNode = clone(newNode);
+
+	estraverse.traverse(clonedNewNode, {
+		enter(node) {
+			node['loc'] = originalNode['loc'];
+			node['start'] = originalNode['start'];
+			node['end'] = originalNode['end'];
+
+			return node;
+		},
+	});
+
+	return clonedNewNode;
+}
 
 /**
  * Programs may have Directives, Statements, and ModuleDeclarations as children,

--- a/packages/liferay-js-toolkit-core/src/transform/js/index.ts
+++ b/packages/liferay-js-toolkit-core/src/transform/js/index.ts
@@ -29,9 +29,9 @@ export async function replace(
 	visitor: estraverse.Visitor
 ): Promise<SourceCode> {
 	// TODO: clone source.ast to avoid modifying source?
-	const ast = source.ast || parse(source.code);
+	let ast = source.ast || parse(source.code);
 
-	estraverse.replace(ast as estree.Node, visitor);
+	ast = estraverse.replace(ast as estree.Node, visitor);
 
 	const file = source.map ? source.map.file : '<unknown>';
 

--- a/packages/liferay-npm-bundler/src/steps/adapt/angular-cli/tweakAttachmentToDOM.ts
+++ b/packages/liferay-npm-bundler/src/steps/adapt/angular-cli/tweakAttachmentToDOM.ts
@@ -5,9 +5,14 @@
 
 import {
 	JsSourceTransform,
+	mapAstNodeLocation,
 	parseAsAstExpressionStatement,
 	replaceJsSource,
 } from 'liferay-js-toolkit-core';
+
+const {expression: portletElementIdExpression} = parseAsAstExpressionStatement(
+	`'#' + _LIFERAY_PARAMS_.portletElementId`
+);
 
 /**
  * Changes `'app-root'` to `'#'+_LIFERAY_PARAMS_.portletElementId` so that
@@ -23,11 +28,7 @@ export default function tweakAttachmentToDOM(domId: string): JsSourceTransform {
 					return;
 				}
 
-				const {expression} = parseAsAstExpressionStatement(
-					`'#' + _LIFERAY_PARAMS_.portletElementId`
-				);
-
-				return expression;
+				return mapAstNodeLocation(portletElementIdExpression, node);
 			},
 		})) as JsSourceTransform;
 }

--- a/packages/liferay-npm-bundler/src/steps/adapt/transform/js/operation/adaptStaticURLsAtRuntime.ts
+++ b/packages/liferay-npm-bundler/src/steps/adapt/transform/js/operation/adaptStaticURLsAtRuntime.ts
@@ -5,6 +5,7 @@
 
 import {
 	JsSourceTransform,
+	mapAstNodeLocation,
 	parseAsAstExpressionStatement,
 	replaceJsSource,
 } from 'liferay-js-toolkit-core';
@@ -44,9 +45,11 @@ export default function adaptStaticURLsAtRuntime(
 					return;
 				}
 
-				return parseAsAstExpressionStatement(`
+				const adaptExpression = parseAsAstExpressionStatement(`
 					_ADAPT_RT_.adaptStaticURL("${node.value}")
 				`);
+
+				return mapAstNodeLocation(adaptExpression, node);
 			},
 		});
 	}) as JsSourceTransform;

--- a/packages/liferay-npm-bundler/src/steps/bundle/adapt/replaceWebpackJsonp.ts
+++ b/packages/liferay-npm-bundler/src/steps/bundle/adapt/replaceWebpackJsonp.ts
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-import {JsSourceTransform, replaceJsSource} from 'liferay-js-toolkit-core';
+import {
+	JsSourceTransform,
+	mapAstNodeLocation,
+	replaceJsSource,
+} from 'liferay-js-toolkit-core';
 import {parseAsExpressionStatement} from 'liferay-js-toolkit-core/lib/transform/js/parse';
 
 const {expression: webpackManifestExpression} = parseAsExpressionStatement(
@@ -25,7 +29,7 @@ export default function replaceWebpackJsonp(): JsSourceTransform {
 					node.property.type === 'Literal' &&
 					node.property.value === 'webpackJsonp'
 				) {
-					return webpackManifestExpression;
+					return mapAstNodeLocation(webpackManifestExpression, node);
 				}
 			},
 		})) as JsSourceTransform;


### PR DESCRIPTION
Don't break source maps for single source transformations.

Note that this doesn't fix the case where one single output file maps to multiple input files.

See https://github.com/liferay/liferay-js-toolkit/issues/565#issuecomment-654883046 for more info.