### PR TITLE
test: fix test failures

### DIFF
--- a/packages/liferay-npm-bundler/src/jar/__tests__/manifest.test.js
+++ b/packages/liferay-npm-bundler/src/jar/__tests__/manifest.test.js
@@ -11,7 +11,7 @@ it('returns essential headers', () => {
 	expect(manifest.content).toEqual(
 		`Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Tool: liferay-npm-bundler-2.18.7
+Tool: liferay-npm-bundler-2.18.8
 `
 	);
 });
@@ -25,7 +25,7 @@ it('includes Bundle-SymbolicName when provided', () => {
 		`Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: My wonderful bundle
-Tool: liferay-npm-bundler-2.18.7
+Tool: liferay-npm-bundler-2.18.8
 `
 	);
 });
@@ -39,7 +39,7 @@ it('includes Bundle-Version when provided', () => {
 		`Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Version: 1.0.0
-Tool: liferay-npm-bundler-2.18.7
+Tool: liferay-npm-bundler-2.18.8
 `
 	);
 });
@@ -53,7 +53,7 @@ it('includes Bundle-Name when provided', () => {
 		`Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: my-wonderful-bundle
-Tool: liferay-npm-bundler-2.18.7
+Tool: liferay-npm-bundler-2.18.8
 `
 	);
 });
@@ -66,7 +66,7 @@ it('includes Web-ContextPath when provided', () => {
 	expect(manifest.content).toEqual(
 		`Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Tool: liferay-npm-bundler-2.18.7
+Tool: liferay-npm-bundler-2.18.8
 Web-ContextPath: /my-wonderful-bundle
 `
 	);
@@ -81,7 +81,7 @@ it('includes Provide-Capability when provided', () => {
 		`Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Provide-Capability: my-capability;capability-value
-Tool: liferay-npm-bundler-2.18.7
+Tool: liferay-npm-bundler-2.18.8
 `
 	);
 });
@@ -95,7 +95,7 @@ it('includes Require-Capability when provided', () => {
 		`Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Require-Capability: my-capability;filter:=capability-value
-Tool: liferay-npm-bundler-2.18.7
+Tool: liferay-npm-bundler-2.18.8
 `
 	);
 });
@@ -110,7 +110,7 @@ describe('addCustomHeader', () => {
 		expect(manifest.content).toEqual(
 			`Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Tool: liferay-npm-bundler-2.18.7
+Tool: liferay-npm-bundler-2.18.8
 Custom-Header: Custom value
 Custom-Header-2: Custom value 2
 `


### PR DESCRIPTION
Due to mismatching version numbers; example failing run:

https://travis-ci.org/github/liferay/liferay-js-toolkit/builds/706844909

Note; targeting this against `master` instead of `develop` for now because `develop` is one commit behind at the moment.