### PR TITLE
fix: make namespace-amd-define work with css-loader

### DIFF
--- a/packages/babel-plugin-namespace-amd-define/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin-namespace-amd-define/src/__tests__/__snapshots__/index.test.js.snap
@@ -66,3 +66,10 @@ exports[`namespaces unqualified define calls 1`] = `
 "
 Liferay.Loader.define([], function () {});"
 `;
+
+exports[`namespaces unqualified define calls that are wrapped 1`] = `
+"
+function defineModule() {
+	Liferay.Loader.define([], function () {});
+}"
+`;

--- a/packages/babel-plugin-namespace-amd-define/src/__tests__/index.test.js
+++ b/packages/babel-plugin-namespace-amd-define/src/__tests__/index.test.js
@@ -61,6 +61,22 @@ it('namespaces unqualified define calls', () => {
 	expect(code).toMatchSnapshot();
 });
 
+it('namespaces unqualified define calls that are wrapped', () => {
+	// eg. the css-loader produces wrappers like this.
+	const source = `
+		function defineModule() {
+			define([], function () {});
+		}
+	`;
+
+	const {code} = babel.transform(source, {
+		filename: __filename,
+		plugins: [plugin],
+	});
+
+	expect(code).toMatchSnapshot();
+});
+
 it('does not namespace already qualified define calls', () => {
 	const source = `
 	Other.Namespace.define([], function(){})

--- a/packages/babel-plugin-namespace-amd-define/src/index.js
+++ b/packages/babel-plugin-namespace-amd-define/src/index.js
@@ -37,7 +37,11 @@ export default function() {
 				}
 
 				if (!firstDefineNamespaced) {
-					if (path.scope.parent === null) {
+					if (
+						path.scope.parent === null ||
+						(!path.scope.hasOwnBinding('define') &&
+							!path.scope.hasBinding('define'))
+					) {
 						const namespace =
 							this.opts.namespace || 'Liferay.Loader';
 


### PR DESCRIPTION
As noted in [this liferay-portal PR](https://github.com/liferay-frontend/liferay-portal/pull/345#issuecomment-684867451), code like this which is produced by the css-loader:

```js
function defineModule() {
  define("frontend-js-web@4.0.27/liferay/modal/Modal.scss", ['module', 'exports', 'require'], function (module, exports, require) {
    var define = undefined;
    var global = window;
    {
      module.exports = link;
    }
  });
}
```

winds up with a naked `define` in it, instead of the expected `Liferay.Loader.define`.

This behavior regressed in 0c14c6970503d66d73cb5b311d15ce5748d9eca5.

Now, I don't have enough context to know whether this is the right fix, because the issues listed in that commit are kind of opaque to me. Hopefully @izaera can confirm or refute that the proposed change here is safe.

Of course, it's not very clever; if you have code like this:

```js
function a() {
  define([], function () {});
}

define([], function () {});
```

It is going to namespace the first `define` it sees and warn about the second one, but it's totally arbitrary; there is nothing "special" about the first one that appeared higher up in the file. If move the function to the bottom, then the other `define` "wins" and gets transformed.