### PR TITLE
feat: make a wrapper script for Lerna that autodetects the right remote

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Note that the `link-js-toolkit` will move all JS Toolkit dependencies in the QA 
 
 The release policy is to always release all packages in the monorepo, whether they have been modified or not.
 
-To release a new version run `yarn release` in the `master` branch of the upstream repo (not your fork). This is necessary since lerna adds tags and pushes commits directly to the upstream repo.
+To release a new version run `yarn release` in the `master` branch. The script will attempt to locate the appropriate Git remote corresponding to [the "liferay" organization on GitHub](https://github.com/liferay), and fall back to Lerna's default, the `origin` remote as a last resort.
 
 Make sure the local "master" branch is up-to-date:
 
@@ -121,13 +121,6 @@ Release a new version
 
 ```sh
 $ yarn release ⏎
-```
-
-**NOTE:** Lerna will push to your Git `origin` remote; if that happens to be _your_ fork and not the official [liferay/liferay-js-toolkit](https://github.com/liferay/liferay-js-toolkit), then you will need to push the changes upstream manually. For example, if the authoritative remote is named `upstream` in your local repo:
-
-```sh
-git push upstream master --follow-tags --dry-run ⏎
-git push upstream master --follow-tags ⏎
 ```
 
 Copy the relevant section from the changelog to the corresponding entry on the [releases page](https://github.com/liferay/liferay-js-toolkit/releases).

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
 		"lint": "eslint \"packages/*/src/*.js\" \"packages/*/src/**/*.js\"",
 		"lint:fix": "eslint --fix \"packages/*/src/*.js\" \"packages/*/src/**/*.js\"",
 		"qa": "node scripts/qa/index.js",
-		"release": "lerna publish --force-publish='*' --exact",
-		"release-canary": "lerna publish --force-publish='*' --exact -c",
+		"release": "scripts/publish.sh --force-publish='*' --exact",
+		"release-canary": "scripts/publish.sh --force-publish='*' --exact -c",
 		"test": "jest --runInBand",
 		"watch": "node scripts/watch"
 	},

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# © 2017 Liferay, Inc. <https://liferay.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+##
+# Wrapper for `lerna publish` that attempts to detect the appropriate remote to
+# use and passes `--git-remote` accordingly.
+#
+
+REMOTE=$(git remote -v | grep 'github.com[:/]liferay/' | grep '(push)' | sort -k2 | head -1 | cut -f1)
+
+if [ -n "$REMOTE" ]; then
+	yarn run lerna "$@" --git-remote="$REMOTE"
+else
+	echo 'warning: could not locate a "liferay" remote'
+
+	read -p 'Proceed using "origin" remote? ' -n 1 -r
+	echo
+
+	if [[ $REPLY =~ ^[Yy]$ ]]; then
+		yarn run lerna "$@"
+	else
+		echo Aborted.
+		exit 1
+	fi
+fi


### PR DESCRIPTION
As I discovered in my first attempt at publishing the JS toolkit yesterday, Lerna will push to your "origin" remote, which in my case was my fork; ie. my `git remote -v` output is:

    origin	git@github.com:wincent/liferay-js-toolkit.git (fetch)
    origin	git@github.com:wincent/liferay-js-toolkit.git (push)
    upstream	https://github.com/liferay/liferay-js-toolkit.git (fetch)
    upstream	https://github.com/liferay/liferay-js-toolkit.git (push)
    upstream-rw	git@github.com:liferay/liferay-js-toolkit.git (fetch)
    upstream-rw	git@github.com:liferay/liferay-js-toolkit.git (push)

This commit adds a wrapper that uses this pipeline to try and pick the right remote automatically:

-   `git remote -v`: list all remotes.
-   `grep 'github.com[:/]liferay/'`: Pick out "liferay" ones.
-   `grep '(push)'`: Ignore "(fetch)" URLs, look at "(push)" URLs.
-   `sort -k2`: Sort by column 2 (URL); this prioritizes SSH URLs.
-   `head -1`: Grab winner.
-   `cut -f1`: Print the name (ie. "upstream-rw").

We prefer SSH URLs because they are more likely to be the preferred URLs for write access.

Updated the docs accordingly.

Test plan:

1.  Prepended "echo" to those "yarn" commands so that I could run without
    actually publishing.

2.  Run "yarn release"; see it print:

    ```
    yarn run lerna --help --force-publish=* --exact --git-remote=upstream-rw
    ```

3.  Edit then "grep" to search for "liferayz" instead of "liferay"; see:

    ```
    warning: could not locate a "liferay" remote
    Proceed using "origin" remote? n
    Aborted.
    ```

4.  Repeat, but this time answer "y":

    ```
    warning: could not locate a "liferay" remote
    Proceed using "origin" remote? y
    yarn run lerna --force-publish=* --exact
    ```