### PR TITLE
revert: feat(css-loader): use preload when available (#631)

### DIFF
--- a/packages/liferay-npm-bundler-loader-css-loader/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/liferay-npm-bundler-loader-css-loader/src/__tests__/__snapshots__/index.test.js.snap
@@ -3,24 +3,7 @@
 exports[`java projects correctly generates JS module 1`] = `
 "
 var link = document.createElement(\\"link\\");
-
-var preload;
-
-try {
-	preload = link.relList.supports(\\"preload\\");
-}
-catch (error) {
-	preload = false;
-}
-
-if (preload) {
-	link.setAttribute(\\"as\\", \\"style\\");
-	link.setAttribute(\\"rel\\", \\"preload\\");
-}
-else {
-	link.setAttribute(\\"rel\\", \\"stylesheet\\");
-}
-
+link.setAttribute(\\"rel\\", \\"stylesheet\\");
 link.setAttribute(\\"type\\", \\"text/css\\");
 link.setAttribute(\\"href\\", Liferay.ThemeDisplay.getPathContext() + \\"/o/java-project/file.css\\");
 
@@ -49,24 +32,7 @@ module.exports = link;
 exports[`standard projects correctly generates JS module 1`] = `
 "
 var link = document.createElement(\\"link\\");
-
-var preload;
-
-try {
-	preload = link.relList.supports(\\"preload\\");
-}
-catch (error) {
-	preload = false;
-}
-
-if (preload) {
-	link.setAttribute(\\"as\\", \\"style\\");
-	link.setAttribute(\\"rel\\", \\"preload\\");
-}
-else {
-	link.setAttribute(\\"rel\\", \\"stylesheet\\");
-}
-
+link.setAttribute(\\"rel\\", \\"stylesheet\\");
 link.setAttribute(\\"type\\", \\"text/css\\");
 link.setAttribute(\\"href\\", Liferay.ThemeDisplay.getPathContext() + \\"/o/a-project/file.css\\");
 

--- a/packages/liferay-npm-bundler-loader-css-loader/src/index.js
+++ b/packages/liferay-npm-bundler-loader-css-loader/src/index.js
@@ -29,24 +29,7 @@ export default function(
 	// returns both pathProxy and the context path of the portal's webapp.
 	context.extraArtifacts[`${filePath}.js.wrap-modules-amd.template`] = `
 var link = document.createElement("link");
-
-var preload;
-
-try {
-	preload = link.relList.supports("preload");
-}
-catch (error) {
-	preload = false;
-}
-
-if (preload) {
-	link.setAttribute("as", "style");
-	link.setAttribute("rel", "preload");
-}
-else {
-	link.setAttribute("rel", "stylesheet");
-}
-
+link.setAttribute("rel", "stylesheet");
 link.setAttribute("type", "text/css");
 link.setAttribute("href", Liferay.ThemeDisplay.getPathContext() + "${href}");
 


### PR DESCRIPTION
This reverts commit 1423ca31e3a1f10, because the feature doesn't work as expected, as [described in this comment](https://github.com/liferay-frontend/liferay-portal/pull/345#issuecomment-694221607).

In short, our testing showed the loader producing code that correctly inserted `preload` links in the `head`, and the network pane showed the corresponding resources being fetched, and in the right order. But the associated styles were not being applied to the DOM, leading to visual inconsistencies, as well as undesirable console spew of the form:

> The resource .../css/ApplicationsMenu.css was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.

To fix this, we might be able to add a second, non-`preload`-ing `link` tag, but that would defeat the purpose of our original change, which was to improve our Lighthouse metrics.

So, reverting this for now. We might revisit `preload` for this or some other purpose in the future.

Original PR: https://github.com/liferay/liferay-js-toolkit/pull/632