### PR TITLE
fix(common): allow presets that have a named-scope

### DIFF
--- a/packages/liferay-npm-build-tools-common/src/project/index.ts
+++ b/packages/liferay-npm-build-tools-common/src/project/index.ts
@@ -203,7 +203,9 @@ export class Project {
 			const preset = _npmbundlerrc['preset'];
 
 			if (preset) {
-				putInMap(splitModuleName(preset).pkgName);
+				const {pkgName, scope} = splitModuleName(preset);
+
+				putInMap(scope ? `${scope}/${pkgName}` : pkgName);
 			}
 
 			map = new Map([...map, ...this.transform.versionsInfo]);
@@ -374,10 +376,12 @@ export class Project {
 				basedir: this.dir.asNative,
 			});
 
-			const {pkgName} = splitModuleName(config.preset);
+			const {pkgName, scope} = splitModuleName(config.preset);
 
 			const presetPkgJsonFilePath = resolveModule.sync(
-				`${pkgName}/package.json`,
+				scope
+					? `${scope}/${pkgName}/package.json`
+					: `${pkgName}/package.json`,
 				{
 					basedir: this.dir.asNative,
 				}


### PR DESCRIPTION
[This PR](https://github.com/liferay-frontend/liferay-portal/pull/409) was exploding in CI with the misleading message:

    A problem occurred evaluating project ':apps:frontend-editor:frontend-editor-ckeditor-web'.
    > Ambiguous method overloading for method java.io.File#<init>.
      Cannot resolve which method to invoke for
      [null, class java.lang.String] due to overlapping prototypes
      [class java.io.File, class java.lang.String]
      [class java.lang.String, class java.lang.String]

If you run `yarn build` directly you can see the real cause:

    Error: Cannot find module 'liferay-npm-bundler-preset-liferay-dev' from '/Users/greghurrell/code/portal/

Which reveals the culprit: [this line](https://github.com/liferay/liferay-frontend-projects/blob/fda8587ef8268bcf423e4adb0ae00392e754716d/projects/npm-tools/packages/npm-scripts/src/config/npm-bundler.json#L2) needs to be updated in npm-scripts from:

    "preset": "liferay-npm-bundler-preset-liferay-dev"

To:

    "preset": "@liferay/npm-bundler-preset-liferay-dev"

So I fix that, and it reveals another problem:

    Error: Cannot find module 'npm-bundler-preset-liferay-dev/package.json'
    from '/Users/greghurrell/code/portal/liferay-portal/modules/apps/frontend-editor/frontend-editor-ckeditor-web'

As you can see, the bundler is trying to require `npm-bundler-preset-liferay-dev` instead of the requested `@liferay/npm-preset-liferay-dev`.

This commit implements the minimal fix to unbreak the build, by respecting the scope when it is provided. A `git grep` for `splitModuleName` reveals other places where we are ignoring scopes, and I don't know this project well enough to know why we are doing that, but I suspect we'll have to loop back here later on patch up some more call sites (for example, plugins, loader rules), but for now this is the minimal change. I just don't know why you would ever want to parse out the scope info from the module name and then do nothing with it.

Test plan: hack this change into `node_modules` in a `liferay-portal` checkout and see the build work.