### PR TITLE
docs: tell people to use non-deprecated `@liferay/changelog-generator`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ If any checks fail, fix them, submit a PR, and when it is merged, start again. O
 Update the changelog:
 
 ```sh
-$ npx liferay-changelog-generator --version=v2.19.0 ⏎
+$ npx @liferay/changelog-generator --version=v2.19.0 ⏎
 ```
 
 Review and stage the generated changes:


### PR DESCRIPTION
Seeing as we have moved it into a named scope now and development will continue there:

- Old home: https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-changelog-generator
- New home: https://github.com/liferay/liferay-frontend-projects/tree/master/projects/npm-tools/packages/changelog-generator