### PR TITLE
fix: use a module name placeholder for fragments

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,2 @@
+--publish.tag next
 --version.preid pre

--- a/packages/liferay-npm-bundler/src/adapt/liferay-fragment/index.ts
+++ b/packages/liferay-npm-bundler/src/adapt/liferay-fragment/index.ts
@@ -37,12 +37,10 @@ async function transformBundles(): Promise<void> {
 
 		const destFile = project.outputDir.join(moduleName);
 
-		const {name, version} = project.pkgJson;
-
 		await transformJsSourceFile(
 			sourceFile,
 			destFile,
-			wrapModule(`${name}@${version}/${moduleName}`, {
+			wrapModule(`__FRAGMENT_MODULE_NAME__`, {
 				defineDependencies: {
 					__MODULE__: 'module',
 					__REQUIRE__: 'require',

--- a/packages/liferay-npm-bundler/src/adapt/liferay-fragment/index.ts
+++ b/packages/liferay-npm-bundler/src/adapt/liferay-fragment/index.ts
@@ -40,7 +40,7 @@ async function transformBundles(): Promise<void> {
 		await transformJsSourceFile(
 			sourceFile,
 			destFile,
-			wrapModule(`__FRAGMENT_MODULE_NAME__`, {
+			wrapModule('__FRAGMENT_MODULE_NAME__', {
 				defineDependencies: {
 					__MODULE__: 'module',
 					__REQUIRE__: 'require',


### PR DESCRIPTION
Because the server gives fragment modules a name on-the-fly (based on the fragment entry id) we cannot write any name during build time, so instead we write a placeholder (`__FRAGMENT_MODULE_NAME__`) that the server replaces by the real name when registering the AMD module in the `NPMRegistry`.

This have been tested in my laptop but it needs a very special setup and modifications to the Fragments CLI, so we still need to integrate everything together.