### PR TITLE
docs: add a "redirect" notice to the top-level README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> :warning: The contents of this branch have been migrated [to the `liferay/liferay-frontend-projects` monorepo](https://github.com/liferay/liferay-frontend-projects) and more specifically to the [to the `maintenance/projects/js-toolkit` directory](https://github.com/liferay/liferay-frontend-projects/tree/master/maintenance/projects/js-toolkit). Development will continue there, and this repo will be archived (ie. switched to read-only mode).
+
+---
+
 # liferay-js-toolkit
 
 [![Build Status](https://travis-ci.org/liferay/liferay-js-toolkit.svg?branch=master)](https://travis-ci.org/liferay/liferay-js-toolkit)


### PR DESCRIPTION
This is just like the change made for the 3.x-WIP branch in [#660](https://github.com/liferay/liferay-js-toolkit/pull/660) but with the paths changed.

- https://github.com/liferay/eslint-config-liferay/pull/200
- https://github.com/liferay/liferay-npm-tools/pull/503